### PR TITLE
feat(windows): report client HDR peak luminance

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -174,6 +174,7 @@ SOURCES += \
     backend/identitymanager.cpp \
     backend/nvcomputer.cpp \
     backend/nvhttp.cpp \
+    backend/clientdisplaycapabilities.cpp \
     backend/nvpairingmanager.cpp \
     backend/computermanager.cpp \
     backend/boxartmanager.cpp \
@@ -219,6 +220,7 @@ HEADERS += \
     backend/identitymanager.h \
     backend/nvcomputer.h \
     backend/nvhttp.h \
+    backend/clientdisplaycapabilities.h \
     backend/nvpairingmanager.h \
     backend/computermanager.h \
     backend/boxartmanager.h \
@@ -407,11 +409,13 @@ win32:!winrt {
     message(DXVA2 and D3D11VA renderers selected)
 
     SOURCES += \
+        backend/clientdisplaycapabilities_win.cpp \
         streaming/video/ffmpeg-renderers/dxva2.cpp \
         streaming/video/ffmpeg-renderers/d3d11va.cpp \
         streaming/video/ffmpeg-renderers/pacer/dxvsyncsource.cpp
 
     HEADERS += \
+        backend/clientdisplaycapabilities_win.h \
         streaming/video/ffmpeg-renderers/dxva2.h \
         streaming/video/ffmpeg-renderers/d3d11va.h \
         streaming/video/ffmpeg-renderers/pacer/dxvsyncsource.h

--- a/app/backend/clientdisplaycapabilities.cpp
+++ b/app/backend/clientdisplaycapabilities.cpp
@@ -1,0 +1,19 @@
+#include "clientdisplaycapabilities.h"
+
+#include <cmath>
+
+namespace
+{
+constexpr double kMinPeakLuminanceNits = 1.0;
+constexpr double kMaxPeakLuminanceNits = 100000.0;
+}
+
+std::optional<int> ClientDisplayCapabilities::normalizePeakLuminance(const double nits)
+{
+    if (!std::isfinite(nits) || nits < kMinPeakLuminanceNits ||
+            nits > kMaxPeakLuminanceNits) {
+        return std::nullopt;
+    }
+
+    return static_cast<int>(std::round(nits));
+}

--- a/app/backend/clientdisplaycapabilities.h
+++ b/app/backend/clientdisplaycapabilities.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QString>
+
+#include <optional>
+
+struct ClientDisplayCapabilitySource
+{
+    QString source;
+    double peakLuminanceNits = 0.0;
+};
+
+struct ClientDisplayCapabilities
+{
+    std::optional<ClientDisplayCapabilitySource> calibrated;
+    std::optional<ClientDisplayCapabilitySource> edid;
+
+    static std::optional<int> normalizePeakLuminance(double nits);
+};

--- a/app/backend/clientdisplaycapabilities_win.cpp
+++ b/app/backend/clientdisplaycapabilities_win.cpp
@@ -1,0 +1,1398 @@
+#include "clientdisplaycapabilities_win.h"
+
+#include <QElapsedTimer>
+#include <QSettings>
+
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <Icm.h>
+#include <dxgi1_6.h>
+#include <wrl/client.h>
+
+#include "../SDL_compat.h"
+
+#endif
+
+namespace ClientDisplayCapabilitiesWin
+{
+
+namespace
+{
+
+std::optional<int> normalizePeakNits(double value)
+{
+    if (!std::isfinite(value) || value < 1.0 || value > 100000.0) {
+        return std::nullopt;
+    }
+
+    const double rounded = std::floor(value + 0.5);
+    if (!std::isfinite(rounded) || rounded < 1.0 || rounded > 100000.0) {
+        return std::nullopt;
+    }
+    return static_cast<int>(rounded);
+}
+
+quint32 readBe32(const QByteArray &bytes, qsizetype offset)
+{
+    const auto *data = reinterpret_cast<const uchar *>(bytes.constData() + offset);
+    return (static_cast<quint32>(data[0]) << 24) |
+           (static_cast<quint32>(data[1]) << 16) |
+           (static_cast<quint32>(data[2]) << 8) |
+           static_cast<quint32>(data[3]);
+}
+
+bool sameName(const QString &left, const QString &right)
+{
+    return QString::compare(left, right, Qt::CaseInsensitive) == 0;
+}
+
+bool selectedDisplayIsUsable(const SelectedDisplay &selected)
+{
+    return selected.resolved && selected.unique && selected.hiddenWindowMatches &&
+           selected.displayIndex >= 0 && !selected.gdiDeviceName.isEmpty() &&
+           selected.geometry.width() > 0 && selected.geometry.height() > 0;
+}
+
+bool mappingIsUsable(const SelectedDisplay &selected, const DisplayMapping &mapping)
+{
+    return mapping.valid && mapping.uniqueActivePath && mapping.identityComplete &&
+           mapping.targetAvailable && mapping.displayIndex == selected.displayIndex &&
+           sameName(mapping.gdiDeviceName, selected.gdiDeviceName) &&
+           mapping.desktopBounds == selected.geometry;
+}
+
+bool outputIsUsable(const DisplayMapping &mapping, const DxgiOutputProbe &output)
+{
+    return output.valid && output.current && output.unique && output.attachedToDesktop &&
+           output.adapterIndex == mapping.dxgiAdapterIndex &&
+           output.outputIndex == mapping.dxgiOutputIndex &&
+           sameName(output.deviceName, mapping.outputDeviceName) &&
+           output.desktopBounds == mapping.desktopBounds &&
+           output.colorSpace == DxgiColorSpace::RgbFullG2084NoneP2020;
+}
+
+template <typename OptionalSource>
+void setSource(OptionalSource &destination, const char *source, double peakNits)
+{
+    using Source = typename OptionalSource::value_type;
+    destination = Source { QString::fromLatin1(source), peakNits };
+}
+
+#if defined(_WIN32)
+
+using Microsoft::WRL::ComPtr;
+
+std::uint64_t packLuid(const LUID &luid)
+{
+    return (static_cast<std::uint64_t>(static_cast<std::uint32_t>(luid.HighPart)) << 32) |
+           static_cast<std::uint64_t>(luid.LowPart);
+}
+
+LUID unpackLuid(std::uint64_t value)
+{
+    LUID luid = {};
+    luid.HighPart = static_cast<LONG>(value >> 32);
+    luid.LowPart = static_cast<DWORD>(value & 0xffffffffu);
+    return luid;
+}
+
+bool sameLuid(const LUID &left, std::uint64_t right)
+{
+    return packLuid(left) == right;
+}
+
+struct DisplayConfigSnapshot
+{
+    std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+    std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+};
+
+bool queryActiveDisplayConfig(DisplayConfigSnapshot &snapshot)
+{
+    constexpr UINT32 flags = QDC_ONLY_ACTIVE_PATHS | QDC_VIRTUAL_MODE_AWARE;
+
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        UINT32 pathCount = 0;
+        UINT32 modeCount = 0;
+        if (GetDisplayConfigBufferSizes(flags, &pathCount, &modeCount) != ERROR_SUCCESS) {
+            return false;
+        }
+
+        snapshot.paths.assign(pathCount, DISPLAYCONFIG_PATH_INFO {});
+        snapshot.modes.assign(modeCount, DISPLAYCONFIG_MODE_INFO {});
+        UINT32 actualPathCount = pathCount;
+        UINT32 actualModeCount = modeCount;
+        const LONG result = QueryDisplayConfig(
+            flags,
+            &actualPathCount,
+            snapshot.paths.empty() ? nullptr : snapshot.paths.data(),
+            &actualModeCount,
+            snapshot.modes.empty() ? nullptr : snapshot.modes.data(),
+            nullptr);
+        if (result == ERROR_SUCCESS) {
+            snapshot.paths.resize(actualPathCount);
+            snapshot.modes.resize(actualModeCount);
+            return true;
+        }
+        if (result != ERROR_INSUFFICIENT_BUFFER) {
+            return false;
+        }
+    }
+    return false;
+}
+
+std::optional<std::pair<std::uint32_t, std::uint32_t>> findDxgiOutput(
+    const DisplayMapping &mapping,
+    const SelectedDisplay &selected)
+{
+    ComPtr<IDXGIFactory1> factory;
+    if (FAILED(CreateDXGIFactory1(IID_PPV_ARGS(&factory)))) {
+        return std::nullopt;
+    }
+
+    std::optional<std::pair<std::uint32_t, std::uint32_t>> match;
+    for (UINT adapterIndex = 0;; ++adapterIndex) {
+        ComPtr<IDXGIAdapter1> adapter;
+        if (factory->EnumAdapters1(adapterIndex, &adapter) == DXGI_ERROR_NOT_FOUND) {
+            break;
+        }
+        if (!adapter) {
+            continue;
+        }
+
+        DXGI_ADAPTER_DESC1 adapterDesc = {};
+        if (FAILED(adapter->GetDesc1(&adapterDesc)) ||
+            !sameLuid(adapterDesc.AdapterLuid, mapping.sourceAdapterLuid)) {
+            continue;
+        }
+
+        for (UINT outputIndex = 0;; ++outputIndex) {
+            ComPtr<IDXGIOutput> output;
+            if (adapter->EnumOutputs(outputIndex, &output) == DXGI_ERROR_NOT_FOUND) {
+                break;
+            }
+            if (!output) {
+                continue;
+            }
+
+            DXGI_OUTPUT_DESC outputDesc = {};
+            if (FAILED(output->GetDesc(&outputDesc))) {
+                continue;
+            }
+
+            const QString outputName = QString::fromWCharArray(outputDesc.DeviceName);
+            const QRect bounds(
+                outputDesc.DesktopCoordinates.left,
+                outputDesc.DesktopCoordinates.top,
+                outputDesc.DesktopCoordinates.right - outputDesc.DesktopCoordinates.left,
+                outputDesc.DesktopCoordinates.bottom - outputDesc.DesktopCoordinates.top);
+            if (!sameName(outputName, selected.gdiDeviceName) || bounds != selected.geometry) {
+                continue;
+            }
+
+            const auto candidate = std::make_pair(
+                static_cast<std::uint32_t>(adapterIndex),
+                static_cast<std::uint32_t>(outputIndex));
+            if (match.has_value()) {
+                return std::nullopt;
+            }
+            match = candidate;
+        }
+    }
+    return match;
+}
+
+std::optional<DisplayMapping> mapDisplayConfig(const SelectedDisplay &selected)
+{
+    DisplayConfigSnapshot config;
+    if (!queryActiveDisplayConfig(config)) {
+        return std::nullopt;
+    }
+
+    std::optional<DisplayMapping> match;
+    for (const DISPLAYCONFIG_PATH_INFO &path : config.paths) {
+        if ((path.flags & DISPLAYCONFIG_PATH_ACTIVE) == 0) {
+            continue;
+        }
+
+        DISPLAYCONFIG_SOURCE_DEVICE_NAME sourceName = {};
+        sourceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+        sourceName.header.size = sizeof(sourceName);
+        sourceName.header.adapterId = path.sourceInfo.adapterId;
+        sourceName.header.id = path.sourceInfo.id;
+        if (DisplayConfigGetDeviceInfo(&sourceName.header) != ERROR_SUCCESS ||
+            _wcsicmp(sourceName.viewGdiDeviceName, reinterpret_cast<const wchar_t *>(selected.gdiDeviceName.utf16())) != 0) {
+            continue;
+        }
+
+        if (match.has_value()) {
+            return std::nullopt;
+        }
+
+        DisplayMapping mapping;
+        mapping.valid = true;
+        mapping.uniqueActivePath = true;
+        mapping.identityComplete = true;
+        mapping.displayIndex = selected.displayIndex;
+        mapping.gdiDeviceName = selected.gdiDeviceName;
+        mapping.desktopBounds = selected.geometry;
+        mapping.sourceAdapterLuid = packLuid(path.sourceInfo.adapterId);
+        mapping.sourceId = path.sourceInfo.id;
+        mapping.targetAdapterLuid = packLuid(path.targetInfo.adapterId);
+        mapping.targetId = path.targetInfo.id;
+        mapping.pathFlags = path.flags;
+        mapping.targetAvailable = path.targetInfo.targetAvailable != FALSE;
+        if (!mapping.targetAvailable) {
+            return std::nullopt;
+        }
+
+        const auto dxgiOutput = findDxgiOutput(mapping, selected);
+        if (!dxgiOutput.has_value()) {
+            return std::nullopt;
+        }
+        mapping.dxgiAdapterIndex = dxgiOutput->first;
+        mapping.dxgiOutputIndex = dxgiOutput->second;
+        mapping.outputDeviceName = selected.gdiDeviceName;
+        match = mapping;
+    }
+    return match;
+}
+
+struct DynamicColorProfileApi
+{
+    using GetDisplayUserScope = HRESULT(WINAPI *)(
+        LUID,
+        UINT32,
+        WCS_PROFILE_MANAGEMENT_SCOPE *);
+    using GetDisplayDefault = HRESULT(WINAPI *)(
+        WCS_PROFILE_MANAGEMENT_SCOPE,
+        LUID,
+        UINT32,
+        COLORPROFILETYPE,
+        COLORPROFILESUBTYPE,
+        LPWSTR *);
+    using GetDisplayList = HRESULT(WINAPI *)(
+        WCS_PROFILE_MANAGEMENT_SCOPE,
+        LUID,
+        UINT32,
+        LPWSTR **,
+        PDWORD);
+    using GetColorDirectory = BOOL(WINAPI *)(PCWSTR, PWSTR, PDWORD);
+
+    HMODULE module = nullptr;
+    GetDisplayUserScope getDisplayUserScope = nullptr;
+    GetDisplayDefault getDisplayDefault = nullptr;
+    GetDisplayList getDisplayList = nullptr;
+    GetColorDirectory getColorDirectory = nullptr;
+
+    ~DynamicColorProfileApi()
+    {
+        if (module) {
+            FreeLibrary(module);
+        }
+    }
+
+    bool load()
+    {
+        module = LoadLibraryExW(L"mscms.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        if (!module) {
+            return false;
+        }
+        getDisplayUserScope = reinterpret_cast<GetDisplayUserScope>(
+            GetProcAddress(module, "ColorProfileGetDisplayUserScope"));
+        getDisplayDefault = reinterpret_cast<GetDisplayDefault>(
+            GetProcAddress(module, "ColorProfileGetDisplayDefault"));
+        getDisplayList = reinterpret_cast<GetDisplayList>(
+            GetProcAddress(module, "ColorProfileGetDisplayList"));
+        getColorDirectory = reinterpret_cast<GetColorDirectory>(
+            GetProcAddress(module, "GetColorDirectoryW"));
+        // GetColorDirectoryW is optional on older supported Windows builds;
+        // colorDirectory() has a bounded system-directory fallback.
+        // ColorProfileGetDisplayList is optional so the default-profile path
+        // remains available on older Windows builds.
+        return getDisplayUserScope && getDisplayDefault;
+    }
+};
+
+struct HandleGuard
+{
+    HANDLE handle = INVALID_HANDLE_VALUE;
+
+    ~HandleGuard()
+    {
+        if (handle != INVALID_HANDLE_VALUE && handle != nullptr) {
+            CloseHandle(handle);
+        }
+    }
+
+    explicit operator bool() const
+    {
+        return handle != INVALID_HANDLE_VALUE && handle != nullptr;
+    }
+};
+
+struct FileIdentity
+{
+    ULONGLONG volumeSerial = 0;
+    FILE_ID_128 fileId = {};
+};
+
+bool getFileIdentity(HANDLE handle, FileIdentity &identity)
+{
+    FILE_ID_INFO info = {};
+    if (!GetFileInformationByHandleEx(handle, FileIdInfo, &info, sizeof(info))) {
+        return false;
+    }
+    identity.volumeSerial = info.VolumeSerialNumber;
+    identity.fileId = info.FileId;
+    return true;
+}
+
+bool isReparsePoint(HANDLE handle)
+{
+    FILE_ATTRIBUTE_TAG_INFO info = {};
+    return GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info, sizeof(info)) &&
+           (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+}
+
+std::wstring finalPath(HANDLE handle)
+{
+    DWORD length = GetFinalPathNameByHandleW(handle, nullptr, 0, FILE_NAME_NORMALIZED);
+    if (length == 0) {
+        return {};
+    }
+    std::vector<wchar_t> buffer(static_cast<std::size_t>(length) + 1);
+    const DWORD actual = GetFinalPathNameByHandleW(
+        handle,
+        buffer.data(),
+        static_cast<DWORD>(buffer.size()),
+        FILE_NAME_NORMALIZED);
+    if (actual == 0 || actual >= buffer.size()) {
+        return {};
+    }
+    return std::wstring(buffer.data(), actual);
+}
+
+bool startsWithInsensitive(const std::wstring &value, const wchar_t *prefix)
+{
+    const std::wstring_view prefixView(prefix);
+    if (value.size() < prefixView.size()) {
+        return false;
+    }
+    return CompareStringOrdinal(
+               value.data(), static_cast<int>(prefixView.size()),
+               prefixView.data(), static_cast<int>(prefixView.size()), TRUE) == CSTR_EQUAL;
+}
+
+std::wstring normalizeFinalPath(std::wstring path)
+{
+    if (startsWithInsensitive(path, L"\\\\?\\UNC\\")) {
+        path.erase(0, 8);
+        path.insert(0, L"\\\\");
+    }
+    else if (startsWithInsensitive(path, L"\\\\?\\")) {
+        path.erase(0, 4);
+    }
+
+    while (path.size() > 1 && (path.back() == L'\\' || path.back() == L'/')) {
+        // Keep a drive root such as C:\\ intact.
+        if (path.size() == 3 && path[1] == L':') {
+            break;
+        }
+        path.pop_back();
+    }
+    return path;
+}
+
+bool isDirectChildPath(
+    const std::wstring &directoryPath,
+    const std::wstring &candidatePath,
+    const std::wstring &profileName)
+{
+    const std::wstring directory = normalizeFinalPath(directoryPath);
+    const std::wstring candidate = normalizeFinalPath(candidatePath);
+    if (directory.empty() || candidate.size() <= directory.size()) {
+        return false;
+    }
+    if (CompareStringOrdinal(
+            candidate.data(), static_cast<int>(directory.size()),
+            directory.data(), static_cast<int>(directory.size()), TRUE) != CSTR_EQUAL) {
+        return false;
+    }
+    const wchar_t separator = candidate[directory.size()];
+    if (separator != L'\\' && separator != L'/') {
+        return false;
+    }
+    const std::wstring suffix = candidate.substr(directory.size() + 1);
+    return CompareStringOrdinal(
+               suffix.data(), static_cast<int>(suffix.size()),
+               profileName.data(), static_cast<int>(profileName.size()), TRUE) == CSTR_EQUAL;
+}
+
+std::optional<std::wstring> colorDirectory(DynamicColorProfileApi &api)
+{
+    if (!api.getColorDirectory) {
+        wchar_t windowsDirectory[MAX_PATH] = {};
+        const UINT length = GetSystemWindowsDirectoryW(
+            windowsDirectory,
+            ARRAYSIZE(windowsDirectory)
+        );
+        if (length == 0 || length >= ARRAYSIZE(windowsDirectory)) {
+            return std::nullopt;
+        }
+        return std::wstring(windowsDirectory, length) +
+               L"\\System32\\spool\\drivers\\color";
+    }
+
+    DWORD size = MAX_PATH;
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        std::vector<wchar_t> buffer(size + 1, L'\0');
+        DWORD requested = size;
+        if (api.getColorDirectory(nullptr, buffer.data(), &requested)) {
+            return std::wstring(buffer.data());
+        }
+        if (requested <= size) {
+            return std::nullopt;
+        }
+        size = requested + 1;
+    }
+    return std::nullopt;
+}
+
+std::optional<FILE_ID_128> findDirectChildId(HANDLE directory, const std::wstring &profileName)
+{
+    std::vector<std::byte> buffer(64 * 1024);
+    if (!GetFileInformationByHandleEx(
+            directory,
+            FileIdExtdDirectoryRestartInfo,
+            buffer.data(),
+            static_cast<DWORD>(buffer.size()))) {
+        return std::nullopt;
+    }
+
+    while (true) {
+        auto *entry = reinterpret_cast<FILE_ID_EXTD_DIR_INFO *>(buffer.data());
+        while (true) {
+            const std::wstring name(
+                entry->FileName,
+                entry->FileNameLength / sizeof(wchar_t));
+            if (CompareStringOrdinal(
+                    name.data(), static_cast<int>(name.size()),
+                    profileName.data(), static_cast<int>(profileName.size()), TRUE) == CSTR_EQUAL) {
+                return entry->FileId;
+            }
+            if (entry->NextEntryOffset == 0) {
+                break;
+            }
+            entry = reinterpret_cast<FILE_ID_EXTD_DIR_INFO *>(
+                reinterpret_cast<std::byte *>(entry) + entry->NextEntryOffset);
+        }
+
+        // The directory API is stateful: subsequent calls continue from the
+        // retained directory handle.
+        if (!GetFileInformationByHandleEx(
+                directory,
+                FileIdExtdDirectoryInfo,
+                buffer.data(),
+                static_cast<DWORD>(buffer.size()))) {
+            break;
+        }
+    }
+    return std::nullopt;
+}
+
+bool sameFileId(const FILE_ID_128 &left, const FILE_ID_128 &right)
+{
+    return std::memcmp(&left, &right, sizeof(FILE_ID_128)) == 0;
+}
+
+struct ProfileReadResult
+{
+    bool completed = false;
+    QByteArray bytes;
+};
+
+struct AsyncProfileReadState
+{
+    HANDLE file = INVALID_HANDLE_VALUE;
+    HANDLE event = nullptr;
+    OVERLAPPED overlapped = {};
+    QByteArray bytes;
+
+    ~AsyncProfileReadState()
+    {
+        if (event != nullptr) {
+            CloseHandle(event);
+        }
+        if (file != INVALID_HANDLE_VALUE && file != nullptr) {
+            CloseHandle(file);
+        }
+    }
+};
+
+void detachProfileReadCleanup(const std::shared_ptr<AsyncProfileReadState> &state)
+{
+    try {
+        std::thread([state] {
+            WaitForSingleObject(state->event, INFINITE);
+            DWORD bytesRead = 0;
+            (void) GetOverlappedResult(state->file, &state->overlapped, &bytesRead, FALSE);
+        }).detach();
+    }
+    catch (...) {
+        // A cleanup thread is normally available. If the process cannot
+        // create one, keep the operation's OVERLAPPED and buffer alive until
+        // cancellation completes rather than returning dangling I/O state.
+        WaitForSingleObject(state->event, INFINITE);
+    }
+}
+
+ProfileReadResult readProfileBytes(HANDLE file, LARGE_INTEGER fileSize, DWORD waitBudgetMs)
+{
+    ProfileReadResult result;
+    if (fileSize.QuadPart < 0 || fileSize.QuadPart > kMaxMhc2ProfileBytes) {
+        return result;
+    }
+
+    auto state = std::make_shared<AsyncProfileReadState>();
+    state->bytes.resize(static_cast<qsizetype>(fileSize.QuadPart));
+    if (!DuplicateHandle(
+            GetCurrentProcess(),
+            file,
+            GetCurrentProcess(),
+            &state->file,
+            0,
+            FALSE,
+            DUPLICATE_SAME_ACCESS)) {
+        state->bytes.clear();
+        return result;
+    }
+    state->event = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    if (state->event == nullptr) {
+        result.bytes.clear();
+        return result;
+    }
+
+    state->overlapped.hEvent = state->event;
+    DWORD bytesRead = 0;
+    const BOOL started = ReadFile(
+        state->file,
+        state->bytes.data(),
+        static_cast<DWORD>(state->bytes.size()),
+        &bytesRead,
+        &state->overlapped);
+    if (!started && GetLastError() != ERROR_IO_PENDING) {
+        return result;
+    }
+
+    if (started) {
+        result.completed = bytesRead == static_cast<DWORD>(state->bytes.size());
+    }
+    else {
+        const DWORD waitResult = WaitForSingleObject(
+            state->event,
+            waitBudgetMs
+        );
+        if (waitResult == WAIT_TIMEOUT) {
+            CancelIoEx(state->file, &state->overlapped);
+            detachProfileReadCleanup(state);
+            return result;
+        }
+        if (waitResult != WAIT_OBJECT_0 ||
+            !GetOverlappedResult(state->file, &state->overlapped, &bytesRead, FALSE)) {
+            if (waitResult != WAIT_OBJECT_0) {
+                CancelIoEx(state->file, &state->overlapped);
+                detachProfileReadCleanup(state);
+            }
+            return result;
+        }
+        result.completed = bytesRead == static_cast<DWORD>(state->bytes.size());
+    }
+
+    if (result.completed) {
+        result.bytes = state->bytes;
+    }
+    return result;
+}
+
+ProfileProbe readProfileFile(
+    DynamicColorProfileApi &api,
+    const QString &profileName,
+    QElapsedTimer &timer,
+    qint64 budgetMs)
+{
+    ProfileProbe result;
+    result.profileType = ProfileType::Icc;
+    result.displayColorMode = DisplayColorMode::Extended;
+    result.profileName = profileName;
+
+    if (!isSafeProfileBasename(result.profileName) || timer.elapsed() >= budgetMs) {
+        return result;
+    }
+
+    const auto directoryPath = colorDirectory(api);
+    if (!directoryPath.has_value()) {
+        return result;
+    }
+    const std::wstring profileNameWide = result.profileName.toStdWString();
+    const std::wstring directoryWide = *directoryPath;
+    const std::wstring candidatePath = directoryWide + L"\\" + profileNameWide;
+
+    HandleGuard directory;
+    directory.handle = CreateFileW(
+        directoryWide.c_str(),
+        FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+        nullptr);
+    if (!directory || isReparsePoint(directory.handle)) {
+        return result;
+    }
+
+    FileIdentity directoryIdentity;
+    if (!getFileIdentity(directory.handle, directoryIdentity)) {
+        return result;
+    }
+    const std::wstring directoryFinalPath = finalPath(directory.handle);
+    if (directoryFinalPath.empty()) {
+        return result;
+    }
+
+    const auto childId = findDirectChildId(directory.handle, profileNameWide);
+    if (!childId.has_value()) {
+        return result;
+    }
+
+    HandleGuard file;
+    file.handle = CreateFileW(
+        candidatePath.c_str(),
+        GENERIC_READ | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_OVERLAPPED,
+        nullptr);
+    if (!file || isReparsePoint(file.handle)) {
+        return result;
+    }
+
+    FileIdentity candidateIdentity;
+    if (!getFileIdentity(file.handle, candidateIdentity) ||
+        candidateIdentity.volumeSerial != directoryIdentity.volumeSerial ||
+        !sameFileId(candidateIdentity.fileId, *childId) ||
+        !isDirectChildPath(directoryFinalPath, finalPath(file.handle), profileNameWide)) {
+        return result;
+    }
+
+    LARGE_INTEGER fileSize = {};
+    if (!GetFileSizeEx(file.handle, &fileSize)) {
+        return result;
+    }
+
+    const qint64 remainingBudgetMs = budgetMs - timer.elapsed();
+    if (remainingBudgetMs <= 0) {
+        return result;
+    }
+    const ProfileReadResult read = readProfileBytes(
+        file.handle,
+        fileSize,
+        static_cast<DWORD>(remainingBudgetMs));
+    result.elapsedMs = timer.elapsed();
+    result.readCompleted = read.completed && result.elapsedMs <= budgetMs;
+    if (result.readCompleted) {
+        result.bytes = read.bytes;
+    }
+    return result;
+}
+
+bool isNoExtendedDefaultResult(HRESULT result)
+{
+    return result == S_OK || result == S_FALSE ||
+           result == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) ||
+           result == HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
+}
+
+QStringList readAdvancedColorProfileNames(
+    const DisplayMapping &mapping,
+    WCS_PROFILE_MANAGEMENT_SCOPE scope)
+{
+    const QString sourceKey = QString::number(mapping.sourceId).rightJustified(
+        4, QChar('0'));
+    const QString keyPath = scope == WCS_PROFILE_MANAGEMENT_SCOPE_CURRENT_USER
+        ? QStringLiteral(
+              "HKEY_CURRENT_USER\\Software\\Microsoft\\Windows NT\\CurrentVersion\\"
+              "ICM\\ProfileAssociations\\Display\\{4d36e96e-e325-11ce-bfc1-08002be10318}\\")
+        : QStringLiteral(
+              "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Class\\"
+              "{4d36e96e-e325-11ce-bfc1-08002be10318}\\");
+    const QSettings settings(keyPath + sourceKey, QSettings::NativeFormat);
+    const QVariant value = settings.value(QStringLiteral("ICMProfileAC"));
+
+    QStringList names = value.toStringList();
+    if (names.isEmpty()) {
+        const QString scalar = value.toString();
+        if (!scalar.isEmpty()) {
+            names.push_back(scalar);
+        }
+    }
+    names.removeAll(QString());
+    return names;
+}
+
+ProfileProbe readColorProfile(const DisplayMapping &mapping, qint64 budgetMs)
+{
+    ProfileProbe result;
+    result.lookupStatus = ProfileLookupStatus::Failed;
+    DynamicColorProfileApi api;
+    result.exportsAvailable = api.load();
+    result.osSupported = result.exportsAvailable;
+    if (!result.exportsAvailable) {
+        return result;
+    }
+
+    const LUID targetLuid = unpackLuid(mapping.targetAdapterLuid);
+    WCS_PROFILE_MANAGEMENT_SCOPE scope = WCS_PROFILE_MANAGEMENT_SCOPE_SYSTEM_WIDE;
+    if (FAILED(api.getDisplayUserScope(targetLuid, mapping.sourceId, &scope))) {
+        return result;
+    }
+    result.scopeSupported = true;
+
+    LPWSTR profileName = nullptr;
+    QElapsedTimer timer;
+    timer.start();
+    const HRESULT profileResult = api.getDisplayDefault(
+        scope,
+        targetLuid,
+        mapping.sourceId,
+        CPT_ICC,
+        CPST_EXTENDED_DISPLAY_COLOR_MODE,
+        &profileName);
+    const QString profileNameValue = profileName
+        ? QString::fromWCharArray(profileName)
+        : QString();
+    if (profileName) {
+        LocalFree(profileName);
+    }
+
+    if (profileNameValue.isEmpty()) {
+        if (isNoExtendedDefaultResult(profileResult)) {
+            result.lookupStatus = ProfileLookupStatus::NoExtendedDefault;
+        }
+        return result;
+    }
+    if (FAILED(profileResult)) {
+        return result;
+    }
+
+    result = readProfileFile(api, profileNameValue, timer, budgetMs);
+    result.exportsAvailable = true;
+    result.osSupported = true;
+    result.scopeSupported = true;
+    result.lookupStatus = ProfileLookupStatus::ExtendedDefaultAvailable;
+    return result;
+}
+
+std::vector<ProfileProbe> readAssociatedColorProfiles(
+    const DisplayMapping &mapping,
+    qint64 budgetMs)
+{
+    constexpr DWORD kMaxAssociatedProfiles = 8;
+
+    std::vector<ProfileProbe> result;
+    QElapsedTimer timer;
+    timer.start();
+    if (budgetMs <= 0) {
+        return result;
+    }
+
+    DynamicColorProfileApi api;
+    const bool exportsAvailable = api.load();
+    if (!exportsAvailable || !api.getDisplayList) {
+        return result;
+    }
+
+    const LUID targetLuid = unpackLuid(mapping.targetAdapterLuid);
+    WCS_PROFILE_MANAGEMENT_SCOPE scope = WCS_PROFILE_MANAGEMENT_SCOPE_SYSTEM_WIDE;
+    if (FAILED(api.getDisplayUserScope(targetLuid, mapping.sourceId, &scope))) {
+        return result;
+    }
+
+    QStringList activeNames = readAdvancedColorProfileNames(mapping, scope);
+    QStringList uniqueActiveNames;
+    for (const QString &activeName : activeNames) {
+        if (!activeName.isEmpty() && !uniqueActiveNames.contains(activeName, Qt::CaseInsensitive)) {
+            uniqueActiveNames.push_back(activeName);
+        }
+    }
+    if (uniqueActiveNames.isEmpty() || uniqueActiveNames.size() > kMaxAssociatedProfiles) {
+        return result;
+    }
+
+    LPWSTR *profileList = nullptr;
+    DWORD profileCount = 0;
+    const HRESULT listResult = api.getDisplayList(
+            scope,
+            targetLuid,
+            mapping.sourceId,
+            &profileList,
+            &profileCount);
+    if (FAILED(listResult)) {
+        if (profileList) {
+            LocalFree(profileList);
+        }
+        return result;
+    }
+
+    if (profileList == nullptr || profileCount == 0 ||
+        profileCount > kMaxAssociatedProfiles) {
+        if (profileList) {
+            LocalFree(profileList);
+        }
+        return result;
+    }
+
+    if (timer.elapsed() >= budgetMs) {
+        LocalFree(profileList);
+        return result;
+    }
+
+    QStringList matchedNames;
+    bool complete = true;
+    for (DWORD index = 0; index < profileCount; ++index) {
+        if (profileList[index] == nullptr || timer.elapsed() >= budgetMs) {
+            complete = false;
+            break;
+        }
+
+        const QString profileName = QString::fromWCharArray(profileList[index]);
+        if (!uniqueActiveNames.contains(profileName, Qt::CaseInsensitive) ||
+            matchedNames.contains(profileName, Qt::CaseInsensitive)) {
+            continue;
+        }
+        matchedNames.push_back(profileName);
+
+        ProfileProbe profile = readProfileFile(api, profileName, timer, budgetMs);
+        profile.exportsAvailable = true;
+        profile.osSupported = true;
+        profile.scopeSupported = true;
+        profile.displayColorMode = DisplayColorMode::Extended;
+
+        if (!profile.readCompleted || profile.elapsedMs < 0 ||
+            profile.elapsedMs > budgetMs || !isSafeProfileBasename(profile.profileName)) {
+            continue;
+        }
+        const auto peak = parseMhc2PeakNits(profile.bytes);
+        if (!peak.has_value()) {
+            continue;
+        }
+
+        profile.parsedMhc2PeakNits = *peak;
+        profile.bytes.clear();
+        if (!result.empty()) {
+            // More than one active Advanced Color profile is ambiguous.
+            result.clear();
+            complete = false;
+            break;
+        }
+        result.push_back(std::move(profile));
+    }
+
+    LocalFree(profileList);
+    if (!complete || matchedNames.size() != uniqueActiveNames.size()) {
+        result.clear();
+    }
+    return result;
+}
+
+DxgiOutputProbe readDxgiOutput(const DisplayMapping &mapping)
+{
+    DxgiOutputProbe result;
+    ComPtr<IDXGIFactory1> factory;
+    if (FAILED(CreateDXGIFactory1(IID_PPV_ARGS(&factory)))) {
+        return result;
+    }
+
+    ComPtr<IDXGIAdapter1> adapter;
+    if (factory->EnumAdapters1(mapping.dxgiAdapterIndex, &adapter) != S_OK || !adapter) {
+        return result;
+    }
+    ComPtr<IDXGIOutput> output;
+    if (adapter->EnumOutputs(mapping.dxgiOutputIndex, &output) != S_OK || !output) {
+        return result;
+    }
+
+    DXGI_OUTPUT_DESC outputDesc = {};
+    if (FAILED(output->GetDesc(&outputDesc))) {
+        return result;
+    }
+
+    ComPtr<IDXGIOutput6> output6;
+    if (FAILED(output.As(&output6)) || !output6) {
+        return result;
+    }
+    DXGI_OUTPUT_DESC1 descriptor = {};
+    if (FAILED(output6->GetDesc1(&descriptor))) {
+        return result;
+    }
+
+    result.valid = true;
+    result.current = factory->IsCurrent() != FALSE;
+    result.unique = true;
+    result.attachedToDesktop = outputDesc.AttachedToDesktop != FALSE;
+    result.deviceName = QString::fromWCharArray(outputDesc.DeviceName);
+    result.desktopBounds = QRect(
+        outputDesc.DesktopCoordinates.left,
+        outputDesc.DesktopCoordinates.top,
+        outputDesc.DesktopCoordinates.right - outputDesc.DesktopCoordinates.left,
+        outputDesc.DesktopCoordinates.bottom - outputDesc.DesktopCoordinates.top);
+    result.adapterIndex = mapping.dxgiAdapterIndex;
+    result.outputIndex = mapping.dxgiOutputIndex;
+    result.colorSpace = descriptor.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020
+        ? DxgiColorSpace::RgbFullG2084NoneP2020
+        : DxgiColorSpace::Other;
+    result.maxLuminance = descriptor.MaxLuminance;
+    return result;
+}
+
+SelectedDisplay resolveSelectedDisplay(const QScreen *screen, quintptr hiddenWindow)
+{
+    SelectedDisplay result;
+    if (!screen || hiddenWindow == 0) {
+        return result;
+    }
+
+    const QRect screenGeometry = screen->geometry();
+    const int hiddenDisplayIndex = SDL_GetWindowDisplayIndex(
+        reinterpret_cast<SDL_Window *>(hiddenWindow));
+    std::vector<QRect> displayBounds;
+    for (int index = 0; index < SDL_GetNumVideoDisplays(); ++index) {
+        SDL_Rect bounds = {};
+        if (SDL_GetDisplayBounds(index, &bounds) != 0) {
+            displayBounds.emplace_back();
+            continue;
+        }
+        const QRect displayGeometry(bounds.x, bounds.y, bounds.w, bounds.h);
+        displayBounds.push_back(displayGeometry);
+    }
+
+    const auto resolvedDisplayIndex = resolveDisplayIndex(
+        screenGeometry,
+        hiddenDisplayIndex,
+        displayBounds);
+    if (!resolvedDisplayIndex.has_value()) {
+        return result;
+    }
+    const int displayIndex = *resolvedDisplayIndex;
+    const QRect displayGeometry = displayBounds[displayIndex];
+    result.resolved = true;
+    result.unique = true;
+    result.displayIndex = displayIndex;
+    result.geometry = displayGeometry;
+    int hiddenWindowX = 0;
+    int hiddenWindowY = 0;
+    SDL_GetWindowPosition(
+        reinterpret_cast<SDL_Window *>(hiddenWindow),
+        &hiddenWindowX,
+        &hiddenWindowY);
+    result.hiddenWindowMatches = hiddenDisplayIndex == displayIndex ||
+        (hiddenDisplayIndex < 0 && displayGeometry.contains(QPoint(hiddenWindowX, hiddenWindowY)));
+
+    RECT monitorRect = {
+        displayGeometry.left(),
+        displayGeometry.top(),
+        displayGeometry.right() + 1,
+        displayGeometry.bottom() + 1,
+    };
+    const HMONITOR monitor = MonitorFromRect(&monitorRect, MONITOR_DEFAULTTONULL);
+    if (!monitor) {
+        result.resolved = false;
+        return result;
+    }
+    MONITORINFOEXW monitorInfo = {};
+    monitorInfo.cbSize = sizeof(monitorInfo);
+    if (!GetMonitorInfoW(monitor, &monitorInfo)) {
+        result.resolved = false;
+        return result;
+    }
+    result.gdiDeviceName = QString::fromWCharArray(monitorInfo.szDevice);
+    return result;
+}
+
+#endif
+
+}
+
+std::optional<int> resolveDisplayIndex(
+    const QRect &screenGeometry,
+    int hiddenDisplayIndex,
+    const std::vector<QRect> &displayBounds)
+{
+    if (hiddenDisplayIndex >= 0 &&
+        hiddenDisplayIndex < static_cast<int>(displayBounds.size()) &&
+        displayBounds[hiddenDisplayIndex].width() > 0 &&
+        displayBounds[hiddenDisplayIndex].height() > 0) {
+        return hiddenDisplayIndex;
+    }
+
+    std::optional<int> topLeftMatch;
+    for (int index = 0; index < static_cast<int>(displayBounds.size()); ++index) {
+        if (displayBounds[index].width() <= 0 || displayBounds[index].height() <= 0 ||
+            displayBounds[index].topLeft() != screenGeometry.topLeft()) {
+            continue;
+        }
+        if (topLeftMatch.has_value()) {
+            return std::nullopt;
+        }
+        topLeftMatch = index;
+    }
+    return topLeftMatch;
+}
+
+std::optional<int> parseMhc2PeakNits(const QByteArray &profileBytes)
+{
+    if (profileBytes.size() < 132 || profileBytes.size() > kMaxMhc2ProfileBytes) {
+        return std::nullopt;
+    }
+
+    const quint32 tagCount = readBe32(profileBytes, 128);
+    const qsizetype tableBytes = profileBytes.size() - 132;
+    if (tagCount > static_cast<quint32>(tableBytes / 12)) {
+        return std::nullopt;
+    }
+
+    for (quint32 index = 0; index < tagCount; ++index) {
+        const qsizetype entry = 132 + static_cast<qsizetype>(index) * 12;
+        if (profileBytes[entry] != 'M' || profileBytes[entry + 1] != 'H' ||
+            profileBytes[entry + 2] != 'C' || profileBytes[entry + 3] != '2') {
+            continue;
+        }
+
+        const quint32 offset = readBe32(profileBytes, entry + 4);
+        const quint32 size = readBe32(profileBytes, entry + 8);
+        if (size < 20 || offset > static_cast<quint32>(profileBytes.size()) ||
+            size > static_cast<quint32>(profileBytes.size()) - offset) {
+            return std::nullopt;
+        }
+        const qsizetype tagOffset = static_cast<qsizetype>(offset);
+        if (profileBytes[tagOffset] != 'M' || profileBytes[tagOffset + 1] != 'H' ||
+            profileBytes[tagOffset + 2] != 'C' || profileBytes[tagOffset + 3] != '2') {
+            return std::nullopt;
+        }
+
+        const qint32 fixedPoint = static_cast<qint32>(readBe32(profileBytes, tagOffset + 16));
+        const double peakNits = static_cast<double>(fixedPoint) / 65536.0;
+        return normalizePeakNits(peakNits);
+    }
+    return std::nullopt;
+}
+
+bool isSafeProfileBasename(const QString &profileName)
+{
+    if (profileName.isEmpty() || profileName == QStringLiteral(".") ||
+        profileName == QStringLiteral("..") || profileName.endsWith(QChar('.')) ||
+        profileName.endsWith(QChar(' '))) {
+        return false;
+    }
+
+    if (profileName.contains(QChar('\0')) || profileName.contains(QChar('/')) ||
+        profileName.contains(QChar('\\')) || profileName.contains(QChar(':'))) {
+        return false;
+    }
+
+    if (profileName.size() >= 2 && profileName.at(1) == QChar(':')) {
+        return false;
+    }
+    if (profileName.startsWith(QStringLiteral("\\\\")) ||
+        profileName.startsWith(QStringLiteral("//")) ||
+        profileName.startsWith(QStringLiteral("\\\\?\\")) ||
+        profileName.startsWith(QStringLiteral("\\\\.\\"))) {
+        return false;
+    }
+    return true;
+}
+
+bool isUsableProfileProbe(const ProfileProbe &profile, qint64 measuredElapsedMs)
+{
+    return profile.exportsAvailable && profile.osSupported && profile.scopeSupported &&
+           profile.profileType == ProfileType::Icc &&
+           profile.displayColorMode == DisplayColorMode::Extended &&
+           profile.readCompleted && profile.elapsedMs >= 0 &&
+           profile.elapsedMs <= kProfileReadBudgetMs && measuredElapsedMs >= 0 &&
+           measuredElapsedMs <= kProfileReadBudgetMs &&
+           isSafeProfileBasename(profile.profileName);
+}
+
+std::optional<int> profilePeakNits(const ProfileProbe &profile)
+{
+    if (profile.parsedMhc2PeakNits.has_value()) {
+        return profile.parsedMhc2PeakNits;
+    }
+    return parseMhc2PeakNits(profile.bytes);
+}
+
+std::optional<ClientDisplayPreparation> collectClientDisplayPreparation(
+    const SelectedDisplay &selectedDisplay,
+    const CollectorProvider &provider)
+{
+    if (!selectedDisplayIsUsable(selectedDisplay) || !provider.mapDisplayConfig ||
+        !provider.readColorProfile || !provider.readDxgiOutput || !provider.revalidate) {
+        return std::nullopt;
+    }
+
+    const DisplayMapping mapping = provider.mapDisplayConfig(selectedDisplay);
+    if (!mappingIsUsable(selectedDisplay, mapping)) {
+        return std::nullopt;
+    }
+
+    QElapsedTimer profileTimer;
+    profileTimer.start();
+    const ProfileProbe profile = provider.readColorProfile(mapping, kProfileReadBudgetMs);
+    const qint64 measuredProfileMs = profileTimer.elapsed();
+    const DxgiOutputProbe output = provider.readDxgiOutput(mapping);
+
+    ClientDisplayCapabilities capabilities;
+    bool calibratedProfileFound = false;
+    if (isUsableProfileProbe(profile, measuredProfileMs)) {
+        if (const auto peak = profilePeakNits(profile)) {
+            setSource(capabilities.calibrated, "windows-icc-mhc2", *peak);
+            calibratedProfileFound = true;
+        }
+    }
+
+    if (!calibratedProfileFound &&
+        profile.lookupStatus == ProfileLookupStatus::NoExtendedDefault &&
+        provider.readAssociatedColorProfiles) {
+        const qint64 remainingBudgetMs = kProfileReadBudgetMs - profileTimer.elapsed();
+        if (remainingBudgetMs > 0) {
+            const std::vector<ProfileProbe> associatedProfiles =
+                provider.readAssociatedColorProfiles(mapping, remainingBudgetMs);
+            const qint64 measuredAssociatedProfileMs = profileTimer.elapsed();
+
+            std::vector<QString> validProfileNames;
+            std::optional<int> associatedPeakNits;
+            for (const ProfileProbe &associated : associatedProfiles) {
+                if (!isUsableProfileProbe(associated, measuredAssociatedProfileMs)) {
+                    continue;
+                }
+                const auto peak = profilePeakNits(associated);
+                if (!peak.has_value()) {
+                    continue;
+                }
+
+                bool duplicate = false;
+                for (const QString &validProfileName : validProfileNames) {
+                    if (sameName(validProfileName, associated.profileName)) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (duplicate) {
+                    continue;
+                }
+
+                validProfileNames.push_back(associated.profileName);
+                associatedPeakNits = *peak;
+            }
+
+            // Advanced Color can make the default-profile API return no
+            // profile. Only inherit an active associated profile when there
+            // is exactly one valid MHC2 candidate; otherwise leave the source
+            // unset so DXGI remains the next deterministic fallback.
+            if (validProfileNames.size() == 1 && associatedPeakNits.has_value()) {
+                setSource(capabilities.calibrated, "windows-icc-mhc2", *associatedPeakNits);
+            }
+        }
+    }
+
+    if (outputIsUsable(mapping, output)) {
+        if (const auto peak = normalizePeakNits(output.maxLuminance)) {
+            setSource(capabilities.edid, "dxgi-output", *peak);
+        }
+    }
+
+    if (!provider.revalidate(mapping, output)) {
+        return std::nullopt;
+    }
+    ClientDisplayPreparation preparation;
+    preparation.selectedDisplay = selectedDisplay;
+    preparation.mapping = mapping;
+    preparation.dxgiOutput = output;
+    preparation.capabilities = capabilities;
+    return preparation;
+}
+
+std::optional<CollectedCapabilities> collectCapabilities(
+    const SelectedDisplay &selectedDisplay,
+    const CollectorProvider &provider)
+{
+    const auto preparation = collectClientDisplayPreparation(selectedDisplay, provider);
+    if (!preparation.has_value()) {
+        return std::nullopt;
+    }
+
+    CollectedCapabilities result;
+    if (preparation->capabilities.calibrated.has_value()) {
+        result.calibratedPeakNits = ClientDisplayCapabilities::normalizePeakLuminance(
+            preparation->capabilities.calibrated->peakLuminanceNits);
+    }
+    if (preparation->capabilities.edid.has_value()) {
+        result.edidPeakNits = ClientDisplayCapabilities::normalizePeakLuminance(
+            preparation->capabilities.edid->peakLuminanceNits);
+    }
+    return result;
+}
+
+std::optional<CollectedCapabilities> collectCapabilities(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow,
+    const CollectorProvider &provider)
+{
+    const auto preparation = collectClientDisplayPreparation(
+        selectedScreen, hiddenWindow, provider);
+    if (!preparation.has_value()) {
+        return std::nullopt;
+    }
+
+    CollectedCapabilities result;
+    if (preparation->capabilities.calibrated.has_value()) {
+        result.calibratedPeakNits = ClientDisplayCapabilities::normalizePeakLuminance(
+            preparation->capabilities.calibrated->peakLuminanceNits);
+    }
+    if (preparation->capabilities.edid.has_value()) {
+        result.edidPeakNits = ClientDisplayCapabilities::normalizePeakLuminance(
+            preparation->capabilities.edid->peakLuminanceNits);
+    }
+    return result;
+}
+
+std::optional<ClientDisplayPreparation> collectClientDisplayPreparation(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow,
+    const CollectorProvider &provider)
+{
+    if (!selectedScreen || !provider.resolveSelectedDisplay) {
+        return std::nullopt;
+    }
+    const SelectedDisplay selected = provider.resolveSelectedDisplay(selectedScreen, hiddenWindow);
+    const auto preparation = collectClientDisplayPreparation(selected, provider);
+    if (!preparation.has_value()) {
+        return std::nullopt;
+    }
+    if (provider.revalidateSelected && !provider.revalidateSelected(
+            selectedScreen,
+            hiddenWindow,
+            preparation->selectedDisplay,
+            preparation->mapping,
+            preparation->dxgiOutput)) {
+        return std::nullopt;
+    }
+    return preparation;
+}
+
+std::optional<ClientDisplayCapabilities> collectClientDisplayCapabilities(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow,
+    const CollectorProvider &provider)
+{
+    const auto preparation = collectClientDisplayPreparation(
+        selectedScreen, hiddenWindow, provider);
+    if (!preparation.has_value()) {
+        return std::nullopt;
+    }
+    return preparation->capabilities;
+}
+
+std::optional<ClientDisplayCapabilities> collectClientDisplayCapabilities(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow)
+{
+    return collectClientDisplayCapabilities(
+        selectedScreen,
+        hiddenWindow,
+        makeWindowsCollectorProvider());
+}
+
+#if defined(_WIN32)
+
+CollectorProvider makeWindowsCollectorProvider()
+{
+    CollectorProvider provider;
+    provider.resolveSelectedDisplay = resolveSelectedDisplay;
+    provider.mapDisplayConfig = [](const SelectedDisplay &selected) {
+        const auto mapping = mapDisplayConfig(selected);
+        return mapping.value_or(DisplayMapping {});
+    };
+    provider.readColorProfile = readColorProfile;
+    provider.readAssociatedColorProfiles = readAssociatedColorProfiles;
+    provider.readDxgiOutput = readDxgiOutput;
+    provider.revalidate = [](const DisplayMapping &mapping, const DxgiOutputProbe &captured) {
+        const SelectedDisplay selected {
+            true,
+            true,
+            true,
+            mapping.displayIndex,
+            mapping.gdiDeviceName,
+            mapping.desktopBounds,
+        };
+        const auto current = mapDisplayConfig(selected);
+        if (!current.has_value() ||
+            current->displayIndex != mapping.displayIndex ||
+            current->gdiDeviceName.compare(mapping.gdiDeviceName, Qt::CaseInsensitive) != 0 ||
+            current->outputDeviceName.compare(mapping.outputDeviceName, Qt::CaseInsensitive) != 0 ||
+            current->desktopBounds != mapping.desktopBounds ||
+            current->sourceAdapterLuid != mapping.sourceAdapterLuid ||
+            current->sourceId != mapping.sourceId ||
+            current->targetAdapterLuid != mapping.targetAdapterLuid ||
+            current->targetId != mapping.targetId ||
+            current->pathFlags != mapping.pathFlags ||
+            current->targetAvailable != mapping.targetAvailable ||
+            current->dxgiAdapterIndex != mapping.dxgiAdapterIndex ||
+            current->dxgiOutputIndex != mapping.dxgiOutputIndex) {
+            return false;
+        }
+
+        const DxgiOutputProbe currentOutput = readDxgiOutput(*current);
+        return currentOutput.valid == captured.valid &&
+               currentOutput.current == captured.current &&
+               currentOutput.unique == captured.unique &&
+               currentOutput.attachedToDesktop == captured.attachedToDesktop &&
+               currentOutput.deviceName.compare(captured.deviceName, Qt::CaseInsensitive) == 0 &&
+               currentOutput.desktopBounds == captured.desktopBounds &&
+               currentOutput.adapterIndex == captured.adapterIndex &&
+               currentOutput.outputIndex == captured.outputIndex &&
+               currentOutput.colorSpace == captured.colorSpace &&
+               currentOutput.maxLuminance == captured.maxLuminance;
+    };
+    provider.revalidateSelected = [](const QScreen *screen,
+                                     quintptr hiddenWindow,
+                                     const SelectedDisplay &captured,
+                                     const DisplayMapping &,
+                                     const DxgiOutputProbe &) {
+        const SelectedDisplay current = resolveSelectedDisplay(screen, hiddenWindow);
+        return current.resolved == captured.resolved &&
+               current.unique == captured.unique &&
+               current.hiddenWindowMatches == captured.hiddenWindowMatches &&
+               current.displayIndex == captured.displayIndex &&
+               current.gdiDeviceName.compare(captured.gdiDeviceName, Qt::CaseInsensitive) == 0 &&
+               current.geometry == captured.geometry;
+    };
+    return provider;
+}
+
+#endif
+
+}

--- a/app/backend/clientdisplaycapabilities_win.h
+++ b/app/backend/clientdisplaycapabilities_win.h
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <QByteArray>
+#include <QPoint>
+#include <QRect>
+#include <QScreen>
+#include <QString>
+
+#include "clientdisplaycapabilities.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace ClientDisplayCapabilitiesWin
+{
+
+constexpr qsizetype kMaxMhc2ProfileBytes = 32 * 1024 * 1024;
+constexpr qint64 kProfileReadBudgetMs = 250;
+
+enum class ProfileType
+{
+    Icc,
+    Other,
+};
+
+enum class DisplayColorMode
+{
+    Extended,
+    Standard,
+};
+
+enum class ProfileLookupStatus
+{
+    Unknown,
+    ExtendedDefaultAvailable,
+    NoExtendedDefault,
+    Failed,
+};
+
+enum class DxgiColorSpace
+{
+    RgbFullG2084NoneP2020,
+    Srgb,
+    ScRgb,
+    StudioPq,
+    Other,
+};
+
+// This is the value-only result used by the collector and its fixtures.  It
+// intentionally has no display, profile, adapter, or OS handle identity.
+struct CollectedCapabilities
+{
+    std::optional<int> calibratedPeakNits;
+    std::optional<int> edidPeakNits;
+};
+
+struct SelectedDisplay
+{
+    bool resolved = false;
+    bool unique = false;
+    bool hiddenWindowMatches = false;
+    int displayIndex = -1;
+    QString gdiDeviceName;
+    QRect geometry;
+};
+
+struct DisplayMapping
+{
+    bool valid = false;
+    bool uniqueActivePath = false;
+    bool identityComplete = false;
+    int displayIndex = -1;
+    QString gdiDeviceName;
+    QString outputDeviceName;
+    QRect desktopBounds;
+    std::uint64_t sourceAdapterLuid = 0;
+    std::uint32_t sourceId = 0;
+    std::uint64_t targetAdapterLuid = 0;
+    std::uint32_t targetId = 0;
+    std::uint32_t pathFlags = 0;
+    bool targetAvailable = false;
+    std::uint32_t dxgiAdapterIndex = 0;
+    std::uint32_t dxgiOutputIndex = 0;
+};
+
+// ProfileProbe is provider-owned input.  profileName and bytes are consumed
+// locally and are never copied into CollectedCapabilities or the launch args.
+struct ProfileProbe
+{
+    bool exportsAvailable = false;
+    bool osSupported = false;
+    bool scopeSupported = false;
+    ProfileLookupStatus lookupStatus = ProfileLookupStatus::Unknown;
+    ProfileType profileType = ProfileType::Other;
+    DisplayColorMode displayColorMode = DisplayColorMode::Standard;
+    QString profileName;
+    QByteArray bytes;
+    // Windows collectors parse associated profiles before returning and clear
+    // bytes. Test providers may leave bytes populated for the collector to
+    // parse, so raw profile data remains provider-owned in either case.
+    std::optional<int> parsedMhc2PeakNits;
+    bool readCompleted = false;
+    qint64 elapsedMs = 0;
+};
+
+struct DxgiOutputProbe
+{
+    bool valid = false;
+    bool current = false;
+    bool unique = false;
+    bool attachedToDesktop = false;
+    QString deviceName;
+    QRect desktopBounds;
+    std::uint32_t adapterIndex = 0;
+    std::uint32_t outputIndex = 0;
+    DxgiColorSpace colorSpace = DxgiColorSpace::Other;
+    double maxLuminance = 0.0;
+};
+
+// A completed GUI-thread collection.  Every member is a value copy: no
+// QScreen, SDL window, Windows API object, or mutable OS handle crosses into
+// the connection worker.  The identity fields let Session perform one final
+// collection immediately before handoff instead of trusting an initialization
+// time display snapshot.
+struct ClientDisplayPreparation
+{
+    SelectedDisplay selectedDisplay;
+    DisplayMapping mapping;
+    DxgiOutputProbe dxgiOutput;
+    ClientDisplayCapabilities capabilities;
+};
+
+struct CollectorProvider
+{
+    std::function<SelectedDisplay(const QScreen *, quintptr)> resolveSelectedDisplay;
+    std::function<DisplayMapping(const SelectedDisplay &)> mapDisplayConfig;
+    std::function<ProfileProbe(const DisplayMapping &, qint64 budgetMs)> readColorProfile;
+    std::function<std::vector<ProfileProbe>(const DisplayMapping &, qint64 budgetMs)>
+        readAssociatedColorProfiles;
+    std::function<DxgiOutputProbe(const DisplayMapping &)> readDxgiOutput;
+    std::function<bool(const DisplayMapping &, const DxgiOutputProbe &)> revalidate;
+    std::function<bool(
+        const QScreen *,
+        quintptr,
+        const SelectedDisplay &,
+        const DisplayMapping &,
+        const DxgiOutputProbe &)> revalidateSelected;
+};
+
+// Resolve a Qt-selected display against SDL's native desktop bounds. The
+// hidden SDL probe identity is authoritative when available because Qt and
+// SDL may report different rectangle sizes under Windows DPI scaling.
+std::optional<int> resolveDisplayIndex(
+    const QRect &screenGeometry,
+    int hiddenDisplayIndex,
+    const std::vector<QRect> &displayBounds);
+
+std::optional<int> parseMhc2PeakNits(const QByteArray &profileBytes);
+bool isSafeProfileBasename(const QString &profileName);
+
+std::optional<CollectedCapabilities> collectCapabilities(
+    const SelectedDisplay &selectedDisplay,
+    const CollectorProvider &provider);
+
+std::optional<CollectedCapabilities> collectCapabilities(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow,
+    const CollectorProvider &provider);
+
+std::optional<ClientDisplayPreparation> collectClientDisplayPreparation(
+    const SelectedDisplay &selectedDisplay,
+    const CollectorProvider &provider);
+
+std::optional<ClientDisplayPreparation> collectClientDisplayPreparation(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow,
+    const CollectorProvider &provider);
+
+std::optional<ClientDisplayCapabilities> collectClientDisplayCapabilities(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow,
+    const CollectorProvider &provider);
+
+std::optional<ClientDisplayCapabilities> collectClientDisplayCapabilities(
+    const QScreen *selectedScreen,
+    quintptr hiddenWindow);
+
+#if defined(Q_OS_WIN) || defined(Q_OS_WIN32)
+CollectorProvider makeWindowsCollectorProvider();
+#else
+inline CollectorProvider makeWindowsCollectorProvider()
+{
+    return {};
+}
+#endif
+
+}

--- a/app/backend/nvcomputer.cpp
+++ b/app/backend/nvcomputer.cpp
@@ -58,6 +58,7 @@ NvComputer::NvComputer(QSettings& settings)
     this->appVersion = nullptr;
     this->maxLumaPixelsHEVC = 0;
     this->serverCodecModeSupport = 0;
+    this->clientHdrPeakVersion = 0;
     this->pendingQuit = false;
     this->gpuModel = nullptr;
     this->isSupportedServerVersion = true;
@@ -154,6 +155,13 @@ NvComputer::NvComputer(NvHTTP& http, QString serverInfo)
         // Assume H.264 is always supported
         this->serverCodecModeSupport = SCM_H264;
     }
+
+    bool clientHdrPeakVersionOk = false;
+    const int advertisedClientHdrPeakVersion =
+        NvHTTP::getXmlString(serverInfo, "ClientHdrPeakVersion").toInt(&clientHdrPeakVersionOk);
+    this->clientHdrPeakVersion =
+        clientHdrPeakVersionOk && advertisedClientHdrPeakVersion == kClientHdrPeakVersion ?
+            advertisedClientHdrPeakVersion : 0;
 
     QString maxLumaPixelsHEVC = NvHTTP::getXmlString(serverInfo, "MaxLumaPixelsHEVC");
     if (!maxLumaPixelsHEVC.isEmpty()) {
@@ -560,6 +568,7 @@ bool NvComputer::update(const NvComputer& that)
     ASSIGN_IF_CHANGED(externalPort);
     ASSIGN_IF_CHANGED(pairState);
     ASSIGN_IF_CHANGED(serverCodecModeSupport);
+    ASSIGN_IF_CHANGED(clientHdrPeakVersion);
     ASSIGN_IF_CHANGED(currentGameId);
     ASSIGN_IF_CHANGED(activeAddress);
     ASSIGN_IF_CHANGED(state);

--- a/app/backend/nvcomputer.h
+++ b/app/backend/nvcomputer.h
@@ -32,6 +32,8 @@ private:
     bool pendingQuit;
 
 public:
+    static constexpr int kClientHdrPeakVersion = 1;
+
     NvComputer() = default;
 
     // Caller is responsible for synchronizing read access to the other host
@@ -98,6 +100,9 @@ public:
     QVector<NvDisplayMode> displayModes;
     int maxLumaPixelsHEVC;
     int serverCodecModeSupport;
+    // Ephemeral host capability. This is intentionally not serialized: it is
+    // re-read from serverinfo so stale hosts cannot enable the launch field.
+    int clientHdrPeakVersion = 0;
     QString gpuModel;
     bool isSupportedServerVersion;
 

--- a/app/backend/nvhttp.cpp
+++ b/app/backend/nvhttp.cpp
@@ -205,12 +205,27 @@ NvHTTP::startApp(QString verb,
                  bool localAudio,
                  int gamepadMask,
                  bool persistGameControllersOnDisconnect,
+                 bool sendClientHdrPeak,
+                 int clientHdrPeakCalibratedNits,
+                 int clientHdrPeakEdidNits,
                  QString& rtspSessionUrl)
 {
     int riKeyId;
 
     memcpy(&riKeyId, streamConfig->remoteInputAesIv, sizeof(riKeyId));
     riKeyId = qFromBigEndian(riKeyId);
+
+    QString clientHdrPeakArguments;
+    if (sendClientHdrPeak && (streamConfig->supportedVideoFormats & VIDEO_FORMAT_MASK_10BIT)) {
+        if (clientHdrPeakCalibratedNits > 0) {
+            clientHdrPeakArguments += QStringLiteral("&clientHdrPeakCalibrated=") +
+                                      QString::number(clientHdrPeakCalibratedNits);
+        }
+        if (clientHdrPeakEdidNits > 0) {
+            clientHdrPeakArguments += QStringLiteral("&clientHdrPeakEdid=") +
+                                      QString::number(clientHdrPeakEdidNits);
+        }
+    }
 
     QString response =
             openConnectionToString(m_BaseUrlHttps,
@@ -229,6 +244,7 @@ NvHTTP::startApp(QString verb,
                                    ((streamConfig->supportedVideoFormats & VIDEO_FORMAT_MASK_10BIT) ?
                                        "&hdrMode=1&clientHdrCapVersion=0&clientHdrCapSupportedFlagsInUint32=0&clientHdrCapMetaDataId=NV_STATIC_METADATA_TYPE_1&clientHdrCapDisplayData=0x0x0x0x0x0x0x0x0x0x0" :
                                         "")+
+                                   clientHdrPeakArguments+
                                    "&localAudioPlayMode="+QString::number(localAudio ? 1 : 0)+
                                    "&surroundAudioInfo="+QString::number(SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION(streamConfig->audioConfiguration))+
                                    "&remoteControllersBitmap="+QString::number(gamepadMask)+

--- a/app/backend/nvhttp.h
+++ b/app/backend/nvhttp.h
@@ -170,6 +170,9 @@ public:
              bool localAudio,
              int gamepadMask,
              bool persistGameControllersOnDisconnect,
+             bool sendClientHdrPeak,
+             int clientHdrPeakCalibratedNits,
+             int clientHdrPeakEdidNits,
              QString& rtspSessionUrl);
 
     QVector<NvApp>

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #ifdef Q_OS_WIN32
+#include "backend/clientdisplaycapabilities_win.h"
 // Scaling the icon down on Win32 looks dreadful, so render at lower res
 #define ICON_SIZE 32
 #else
@@ -1739,6 +1740,9 @@ bool Session::startConnectionAsync()
                       m_Preferences->playAudioOnHost,
                       m_InputHandler->getAttachedGamepadMask(),
                       !m_Preferences->multiController,
+                      m_Computer->clientHdrPeakVersion == NvComputer::kClientHdrPeakVersion,
+                      m_ClientHdrPeakCalibratedNits,
+                      m_ClientHdrPeakEdidNits,
                       rtspSessionUrl);
     } catch (const GfeHttpResponseException& e) {
         emit displayLaunchError(tr("Host returned error: %1").arg(e.toQString()));
@@ -1875,6 +1879,10 @@ void Session::start()
     // We're now active
     s_ActiveSession = this;
 
+#ifdef Q_OS_WIN32
+    prepareClientHdrPeakReport();
+#endif
+
     // Initialize the gamepad code with our preferences
     // NB: m_InputHandler must be initialize before starting the connection.
     m_InputHandler = new SdlInputHandler(*m_Preferences, m_StreamConfig.width, m_StreamConfig.height);
@@ -1885,6 +1893,52 @@ void Session::start()
     QObject::connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     thread->start();
 }
+
+#ifdef Q_OS_WIN32
+void Session::prepareClientHdrPeakReport()
+{
+    m_ClientHdrPeakCalibratedNits = 0;
+    m_ClientHdrPeakEdidNits = 0;
+
+    if (!m_Preferences->enableHdr ||
+            !(m_StreamConfig.supportedVideoFormats & VIDEO_FORMAT_MASK_10BIT) ||
+            m_Computer->clientHdrPeakVersion != NvComputer::kClientHdrPeakVersion ||
+            !m_QtWindow || !m_QtWindow->screen()) {
+        return;
+    }
+
+    SDL_Window* probeWindow = StreamUtils::createTestWindow();
+    if (!probeWindow) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "Unable to create HDR display probe window");
+        return;
+    }
+
+    const QRect screenGeometry = m_QtWindow->screen()->geometry();
+    SDL_SetWindowPosition(probeWindow, screenGeometry.left(), screenGeometry.top());
+    const auto capabilities = ClientDisplayCapabilitiesWin::collectClientDisplayCapabilities(
+        m_QtWindow->screen(),
+        reinterpret_cast<quintptr>(probeWindow));
+
+    if (capabilities.has_value()) {
+        if (capabilities->calibrated.has_value()) {
+            m_ClientHdrPeakCalibratedNits = ClientDisplayCapabilities::normalizePeakLuminance(
+                capabilities->calibrated->peakLuminanceNits).value_or(0);
+        }
+        if (capabilities->edid.has_value()) {
+            m_ClientHdrPeakEdidNits = ClientDisplayCapabilities::normalizePeakLuminance(
+                capabilities->edid->peakLuminanceNits).value_or(0);
+        }
+
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "HDR display peak report: ICC/MHC2=%d nits, DXGI/EDID=%d nits",
+                    m_ClientHdrPeakCalibratedNits,
+                    m_ClientHdrPeakEdidNits);
+    }
+
+    SDL_DestroyWindow(probeWindow);
+}
+#endif
 
 void Session::interrupt()
 {

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -146,6 +146,10 @@ signals:
 private:
     void exec();
 
+#ifdef Q_OS_WIN32
+    void prepareClientHdrPeakReport();
+#endif
+
     bool startConnectionAsync();
 
     bool validateLaunch(SDL_Window* testWindow);
@@ -278,6 +282,9 @@ private:
     int m_FlushingWindowEventsRef;
     QStringList m_LaunchWarnings;
     bool m_ShouldExit;
+
+    int m_ClientHdrPeakCalibratedNits = 0;
+    int m_ClientHdrPeakEdidNits = 0;
 
     bool m_AsyncConnectionSuccess;
     int m_PortTestResults;

--- a/tests/hdr/clientdisplaycapabilities_test.pro
+++ b/tests/hdr/clientdisplaycapabilities_test.pro
@@ -1,0 +1,12 @@
+TEMPLATE = app
+TARGET = tst_clientdisplaycapabilities
+QT += testlib
+QT -= gui
+CONFIG += console testcase c++17
+CONFIG -= app_bundle
+
+SOURCES += \
+    $$PWD/tst_clientdisplaycapabilities.cpp \
+    $$PWD/../../app/backend/clientdisplaycapabilities.cpp
+
+INCLUDEPATH += $$PWD/../../app

--- a/tests/hdr/clientdisplaycapabilities_win_test.pro
+++ b/tests/hdr/clientdisplaycapabilities_win_test.pro
@@ -1,0 +1,19 @@
+TEMPLATE = app
+TARGET = tst_clientdisplaycapabilities_win
+QT += testlib gui
+CONFIG += console testcase c++17
+CONFIG -= app_bundle
+
+SOURCES += \
+    $$PWD/tst_clientdisplaycapabilities_win.cpp \
+    $$PWD/../../app/backend/clientdisplaycapabilities.cpp \
+    $$PWD/../../app/backend/clientdisplaycapabilities_win.cpp
+
+INCLUDEPATH += $$PWD/../../app
+
+contains(QT_ARCH, x86_64) {
+    INCLUDEPATH += $$PWD/../../libs/windows/include/x64 \
+                   $$PWD/../../libs/windows/include/x64/SDL2
+    LIBS += -L$$PWD/../../libs/windows/lib/x64 \
+            -lSDL2 dxgi.lib d3d11.lib gdi32.lib user32.lib advapi32.lib
+}

--- a/tests/hdr/hdr.pro
+++ b/tests/hdr/hdr.pro
@@ -1,0 +1,10 @@
+TEMPLATE = subdirs
+CONFIG += ordered
+
+SUBDIRS += capabilities
+capabilities.file = $$PWD/clientdisplaycapabilities_test.pro
+
+win32:!winrt {
+    SUBDIRS += windows
+    windows.file = $$PWD/clientdisplaycapabilities_win_test.pro
+}

--- a/tests/hdr/tst_clientdisplaycapabilities.cpp
+++ b/tests/hdr/tst_clientdisplaycapabilities.cpp
@@ -1,0 +1,59 @@
+#include <QtTest>
+
+#include <limits>
+
+#include "../../app/backend/clientdisplaycapabilities.h"
+
+class ClientDisplayCapabilitiesTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void normalizationRoundsToWholeNits();
+    void normalizationRejectsInvalidValues();
+    void sourceValuesRemainLocalValueOnlyData();
+};
+
+void ClientDisplayCapabilitiesTest::normalizationRoundsToWholeNits()
+{
+    QCOMPARE(ClientDisplayCapabilities::normalizePeakLuminance(999.4), std::optional<int> {999});
+    QCOMPARE(ClientDisplayCapabilities::normalizePeakLuminance(999.5), std::optional<int> {1000});
+    QCOMPARE(ClientDisplayCapabilities::normalizePeakLuminance(999.6), std::optional<int> {1000});
+}
+
+void ClientDisplayCapabilitiesTest::normalizationRejectsInvalidValues()
+{
+    const double invalidValues[] = {
+        0.0,
+        -1.0,
+        100000.1,
+        std::numeric_limits<double>::quiet_NaN(),
+        std::numeric_limits<double>::infinity(),
+    };
+
+    for (const double value : invalidValues) {
+        QVERIFY(!ClientDisplayCapabilities::normalizePeakLuminance(value).has_value());
+    }
+}
+
+void ClientDisplayCapabilitiesTest::sourceValuesRemainLocalValueOnlyData()
+{
+    ClientDisplayCapabilities capabilities;
+    capabilities.calibrated = ClientDisplayCapabilitySource {
+        QStringLiteral("windows-icc-mhc2"),
+        1600.0,
+    };
+    capabilities.edid = ClientDisplayCapabilitySource {
+        QStringLiteral("dxgi-output"),
+        1200.0,
+    };
+
+    QCOMPARE(capabilities.calibrated->source, QStringLiteral("windows-icc-mhc2"));
+    QCOMPARE(capabilities.calibrated->peakLuminanceNits, 1600.0);
+    QCOMPARE(capabilities.edid->source, QStringLiteral("dxgi-output"));
+    QCOMPARE(capabilities.edid->peakLuminanceNits, 1200.0);
+}
+
+QTEST_APPLESS_MAIN(ClientDisplayCapabilitiesTest)
+
+#include "tst_clientdisplaycapabilities.moc"

--- a/tests/hdr/tst_clientdisplaycapabilities_win.cpp
+++ b/tests/hdr/tst_clientdisplaycapabilities_win.cpp
@@ -1,0 +1,395 @@
+#include <QtTest>
+
+#include <vector>
+
+#include "../../app/backend/clientdisplaycapabilities_win.h"
+
+using namespace ClientDisplayCapabilitiesWin;
+
+namespace {
+
+QByteArray mhc2Profile(double peakNits)
+{
+    QByteArray profile(164, '\0');
+
+    auto writeU32 = [&profile](int offset, quint32 value) {
+        profile[offset] = static_cast<char>((value >> 24) & 0xff);
+        profile[offset + 1] = static_cast<char>((value >> 16) & 0xff);
+        profile[offset + 2] = static_cast<char>((value >> 8) & 0xff);
+        profile[offset + 3] = static_cast<char>(value & 0xff);
+    };
+
+    writeU32(128, 1);
+    profile[132] = 'M';
+    profile[133] = 'H';
+    profile[134] = 'C';
+    profile[135] = '2';
+    writeU32(136, 144);
+    writeU32(140, 20);
+    profile[144] = 'M';
+    profile[145] = 'H';
+    profile[146] = 'C';
+    profile[147] = '2';
+    writeU32(160, static_cast<quint32>(qRound64(peakNits * 65536.0)));
+    return profile;
+}
+
+struct Fixture
+{
+    SelectedDisplay selected;
+    DisplayMapping mapping;
+    ProfileProbe profile;
+    DxgiOutputProbe output;
+    bool identityStable = true;
+
+    CollectorProvider provider() const
+    {
+        const Fixture *fixture = this;
+        CollectorProvider provider;
+        provider.resolveSelectedDisplay = [fixture](const QScreen *, quintptr) {
+            return fixture->selected;
+        };
+        provider.mapDisplayConfig = [fixture](const SelectedDisplay &) {
+            return fixture->mapping;
+        };
+        provider.readColorProfile = [fixture](const DisplayMapping &, qint64) {
+            return fixture->profile;
+        };
+        provider.readAssociatedColorProfiles = [fixture](const DisplayMapping &, qint64) {
+            return fixture->associatedProfiles;
+        };
+        provider.readDxgiOutput = [fixture](const DisplayMapping &) {
+            return fixture->output;
+        };
+        provider.revalidate = [fixture](const DisplayMapping &, const DxgiOutputProbe &) {
+            return fixture->identityStable;
+        };
+        provider.revalidateSelected = [fixture](const QScreen *, quintptr,
+                                                const SelectedDisplay &,
+                                                const DisplayMapping &,
+                                                const DxgiOutputProbe &) {
+            return fixture->identityStable;
+        };
+        return provider;
+    }
+
+    std::vector<ProfileProbe> associatedProfiles;
+};
+
+Fixture validFixture()
+{
+    Fixture fixture;
+    fixture.selected.resolved = true;
+    fixture.selected.unique = true;
+    fixture.selected.hiddenWindowMatches = true;
+    fixture.selected.displayIndex = 2;
+    fixture.selected.gdiDeviceName = QStringLiteral("\\\\.\\DISPLAY3");
+    fixture.selected.geometry = QRect(-2560, 0, 2560, 1440);
+
+    fixture.mapping.valid = true;
+    fixture.mapping.uniqueActivePath = true;
+    fixture.mapping.identityComplete = true;
+    fixture.mapping.displayIndex = 2;
+    fixture.mapping.gdiDeviceName = fixture.selected.gdiDeviceName;
+    fixture.mapping.outputDeviceName = QStringLiteral("\\\\.\\DISPLAY3\\Monitor0");
+    fixture.mapping.desktopBounds = fixture.selected.geometry;
+    fixture.mapping.sourceAdapterLuid = 0x100;
+    fixture.mapping.sourceId = 3;
+    fixture.mapping.targetAdapterLuid = 0x200;
+    fixture.mapping.targetId = 4;
+    fixture.mapping.pathFlags = 1;
+    fixture.mapping.targetAvailable = true;
+    fixture.mapping.dxgiAdapterIndex = 1;
+    fixture.mapping.dxgiOutputIndex = 0;
+
+    fixture.profile.exportsAvailable = true;
+    fixture.profile.osSupported = true;
+    fixture.profile.scopeSupported = true;
+    fixture.profile.lookupStatus = ProfileLookupStatus::ExtendedDefaultAvailable;
+    fixture.profile.profileType = ProfileType::Icc;
+    fixture.profile.displayColorMode = DisplayColorMode::Extended;
+    fixture.profile.profileName = QStringLiteral("Display.icc");
+    fixture.profile.bytes = mhc2Profile(999.5);
+    fixture.profile.readCompleted = true;
+    fixture.profile.elapsedMs = 10;
+
+    fixture.output.valid = true;
+    fixture.output.current = true;
+    fixture.output.unique = true;
+    fixture.output.attachedToDesktop = true;
+    fixture.output.deviceName = fixture.mapping.outputDeviceName;
+    fixture.output.desktopBounds = fixture.mapping.desktopBounds;
+    fixture.output.adapterIndex = fixture.mapping.dxgiAdapterIndex;
+    fixture.output.outputIndex = fixture.mapping.dxgiOutputIndex;
+    fixture.output.colorSpace = DxgiColorSpace::RgbFullG2084NoneP2020;
+    fixture.output.maxLuminance = 1200.0;
+    return fixture;
+}
+
+}
+
+class ClientDisplayCapabilitiesWinTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void nullSelectedScreenIsFailClosed();
+    void missingExportsKeepIndependentDxgiFallback();
+    void standardOnlyProfileIsOmitted();
+    void malformedMhc2IsOmitted();
+    void oversizedOrSlowProfileIsBounded();
+    void ambiguousMappingIsFailClosed();
+    void negativeCoordinateMismatchIsFailClosed();
+    void hiddenWindowMismatchIsFailClosed();
+    void unsafeProfileNameKeepsIndependentFallback();
+    void nonPqDetachedOrCloneOutputIsOmitted();
+    void identityMutationInvalidatesBothSources();
+    void bothSourcesAreNormalizedAndReturned();
+    void advancedColorUsesAssociatedMhc2ProfileWhenDefaultIsUnavailable();
+    void ambiguousAssociatedProfilesAreIgnored();
+    void nonExtendedAssociatedProfileIsIgnored();
+    void failedDefaultDoesNotUseAssociatedProfile();
+    void scaledQtGeometryUsesHiddenDisplayIdentity();
+};
+
+void ClientDisplayCapabilitiesWinTest::nullSelectedScreenIsFailClosed()
+{
+    Fixture fixture = validFixture();
+
+    const auto result = collectCapabilities(nullptr, 0, fixture.provider());
+
+    QVERIFY(!result.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::missingExportsKeepIndependentDxgiFallback()
+{
+    Fixture fixture = validFixture();
+    fixture.profile.exportsAvailable = false;
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+    QCOMPARE(*result->edidPeakNits, 1200);
+}
+
+void ClientDisplayCapabilitiesWinTest::standardOnlyProfileIsOmitted()
+{
+    Fixture fixture = validFixture();
+    fixture.profile.displayColorMode = DisplayColorMode::Standard;
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::malformedMhc2IsOmitted()
+{
+    Fixture fixture = validFixture();
+    fixture.profile.bytes = QByteArray(164, '\0');
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+    QCOMPARE(*result->edidPeakNits, 1200);
+}
+
+void ClientDisplayCapabilitiesWinTest::oversizedOrSlowProfileIsBounded()
+{
+    Fixture fixture = validFixture();
+    fixture.profile.bytes = QByteArray(kMaxMhc2ProfileBytes + 1, '\0');
+    QVERIFY(!parseMhc2PeakNits(fixture.profile.bytes).has_value());
+
+    fixture.profile.bytes = mhc2Profile(1000);
+    fixture.profile.elapsedMs = kProfileReadBudgetMs + 1;
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::ambiguousMappingIsFailClosed()
+{
+    Fixture fixture = validFixture();
+    fixture.mapping.uniqueActivePath = false;
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(!result.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::negativeCoordinateMismatchIsFailClosed()
+{
+    Fixture fixture = validFixture();
+    fixture.mapping.desktopBounds.moveLeft(0);
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(!result.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::hiddenWindowMismatchIsFailClosed()
+{
+    Fixture fixture = validFixture();
+    fixture.selected.hiddenWindowMatches = false;
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(!result.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::unsafeProfileNameKeepsIndependentFallback()
+{
+    Fixture fixture = validFixture();
+    fixture.profile.profileName = QStringLiteral("..\\outside.icc");
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::nonPqDetachedOrCloneOutputIsOmitted()
+{
+    Fixture fixture = validFixture();
+    fixture.output.colorSpace = DxgiColorSpace::Srgb;
+    auto result = collectCapabilities(fixture.selected, fixture.provider());
+    QVERIFY(result.has_value());
+    QVERIFY(!result->edidPeakNits.has_value());
+
+    fixture.output.colorSpace = DxgiColorSpace::RgbFullG2084NoneP2020;
+    fixture.output.attachedToDesktop = false;
+    result = collectCapabilities(fixture.selected, fixture.provider());
+    QVERIFY(result.has_value());
+    QVERIFY(!result->edidPeakNits.has_value());
+
+    fixture.output.attachedToDesktop = true;
+    fixture.output.unique = false;
+    result = collectCapabilities(fixture.selected, fixture.provider());
+    QVERIFY(result.has_value());
+    QVERIFY(!result->edidPeakNits.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::identityMutationInvalidatesBothSources()
+{
+    Fixture fixture = validFixture();
+    fixture.identityStable = false;
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(!result.has_value());
+}
+
+void ClientDisplayCapabilitiesWinTest::bothSourcesAreNormalizedAndReturned()
+{
+    const Fixture fixture = validFixture();
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(result->calibratedPeakNits.has_value());
+    QCOMPARE(*result->calibratedPeakNits, 1000);
+    QVERIFY(result->edidPeakNits.has_value());
+    QCOMPARE(*result->edidPeakNits, 1200);
+}
+
+void ClientDisplayCapabilitiesWinTest::advancedColorUsesAssociatedMhc2ProfileWhenDefaultIsUnavailable()
+{
+    Fixture fixture = validFixture();
+    ProfileProbe associated = fixture.profile;
+    associated.profileName = QStringLiteral("HDR Calibrated Profile.icc");
+    associated.bytes = mhc2Profile(2100.0);
+    fixture.profile = {};
+    fixture.profile.lookupStatus = ProfileLookupStatus::NoExtendedDefault;
+    fixture.associatedProfiles = {associated};
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(result->calibratedPeakNits.has_value());
+    QCOMPARE(*result->calibratedPeakNits, 2100);
+}
+
+void ClientDisplayCapabilitiesWinTest::ambiguousAssociatedProfilesAreIgnored()
+{
+    Fixture fixture = validFixture();
+    ProfileProbe first = fixture.profile;
+    first.profileName = QStringLiteral("HDR Calibrated Profile A.icc");
+    first.bytes = mhc2Profile(1000.0);
+    ProfileProbe second = fixture.profile;
+    second.profileName = QStringLiteral("HDR Calibrated Profile B.icc");
+    second.bytes = mhc2Profile(2100.0);
+    fixture.profile = {};
+    fixture.profile.lookupStatus = ProfileLookupStatus::NoExtendedDefault;
+    fixture.associatedProfiles = {first, second};
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+    QCOMPARE(*result->edidPeakNits, 1200);
+}
+
+void ClientDisplayCapabilitiesWinTest::nonExtendedAssociatedProfileIsIgnored()
+{
+    Fixture fixture = validFixture();
+    ProfileProbe associated = fixture.profile;
+    associated.profileName = QStringLiteral("SDR Profile.icc");
+    associated.displayColorMode = DisplayColorMode::Standard;
+    associated.bytes = mhc2Profile(2100.0);
+    fixture.profile = {};
+    fixture.profile.lookupStatus = ProfileLookupStatus::NoExtendedDefault;
+    fixture.associatedProfiles = {associated};
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+    QCOMPARE(*result->edidPeakNits, 1200);
+}
+
+void ClientDisplayCapabilitiesWinTest::failedDefaultDoesNotUseAssociatedProfile()
+{
+    Fixture fixture = validFixture();
+    ProfileProbe associated = fixture.profile;
+    associated.profileName = QStringLiteral("HDR Calibrated Profile.icc");
+    associated.bytes = mhc2Profile(2100.0);
+    fixture.profile = {};
+    fixture.profile.lookupStatus = ProfileLookupStatus::Failed;
+    fixture.associatedProfiles = {associated};
+
+    const auto result = collectCapabilities(fixture.selected, fixture.provider());
+
+    QVERIFY(result.has_value());
+    QVERIFY(!result->calibratedPeakNits.has_value());
+    QVERIFY(result->edidPeakNits.has_value());
+    QCOMPARE(*result->edidPeakNits, 1200);
+}
+
+void ClientDisplayCapabilitiesWinTest::scaledQtGeometryUsesHiddenDisplayIdentity()
+{
+    const std::vector<QRect> displayBounds = {
+        QRect(0, 0, 3840, 2160),
+    };
+
+    const auto result = resolveDisplayIndex(
+        QRect(0, 0, 1920, 1080),
+        0,
+        displayBounds);
+
+    QVERIFY(result.has_value());
+    QCOMPARE(*result, 0);
+}
+
+QTEST_APPLESS_MAIN(ClientDisplayCapabilitiesWinTest)
+
+#include "tst_clientdisplaycapabilities_win.moc"

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -4,7 +4,9 @@ TEMPLATE = subdirs
 CONFIG += ordered
 
 contains(CONFIG, tests) {
-    SUBDIRS += vrr
+    SUBDIRS += vrr hdr
+
+    hdr.file = $$PWD/hdr/hdr.pro
 } else {
     message(VRR tests are disabled; rerun qmake with CONFIG+=tests)
 }


### PR DESCRIPTION
## Current state

Moonlight negotiates HDR streaming capability but does not report the client display's measured HDR peak luminance to the host. The host therefore cannot distinguish calibrated client peak data from its existing fallback data.

## What changed

1. Add a cross-platform client display capability model and peak-luminance normalization.
2. On Windows, probe the selected display in this order:
   1. HDR calibration ICC/MHC2 profile;
   2. associated display ICC/MHC2 profile;
   3. DXGI output and EDID luminance fallback.
3. Reject malformed, out-of-range, ambiguous, non-HDR, or mismatched display/profile data.
4. Read the ephemeral `ClientHdrPeakVersion=1` host capability.
5. For HDR-capable 10-bit sessions, add `clientHdrPeakCalibrated` and `clientHdrPeakEdid` to launch and resume requests.
6. Add common and Windows-specific deterministic tests.

## Why

Reporting the receiving display's own peak luminance lets a capable host use per-display HDR calibration instead of one host-side fallback. Capability gating keeps older hosts unchanged, and keeping the capability ephemeral prevents stale saved host data from enabling unsupported request fields.

## Validation

- Common capability tests: passed (5/5).
- Windows ICC/MHC2 and DXGI/EDID tests: passed (19/19).
- Windows x64 Release `Moonlight.exe`: compiled and linked successfully.
- The subsequent symbol archive/package step was not completed locally because `7z` is not installed; compilation and linking were already complete.
- Paired launch and resume against the matching Vibepollo host both selected the client ICC/MHC2 value of 2000 nits.
- No cursor changes are included.