### PR TITLE
feat(macos): add Metal VRR presentation

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/vt.h
+++ b/app/streaming/video/ffmpeg-renderers/vt.h
@@ -12,7 +12,7 @@ public:
     void setHdrMode(bool enabled) override;
 
 protected:
-    bool isAppleSilicon();
+    bool isAppleSilicon() const;
 
     bool m_HdrMetadataChanged; // Manual reset
     CFDataRef m_MasteringDisplayColorVolume;

--- a/app/streaming/video/ffmpeg-renderers/vt_base.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_base.mm
@@ -30,7 +30,7 @@ VTBaseRenderer::~VTBaseRenderer() {
     }
 }
 
-bool VTBaseRenderer::isAppleSilicon() {
+bool VTBaseRenderer::isAppleSilicon() const {
     static uint32_t cpuType = 0;
     if (cpuType == 0) {
         size_t size = sizeof(cpuType);

--- a/app/streaming/video/ffmpeg-renderers/vt_metal.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_metal.mm
@@ -3,6 +3,7 @@
 #define AVMediaType AVMediaType_FFmpeg
 #include "vt.h"
 #include "pacer/pacer.h"
+#include "ivrrframepresenter.h"
 #undef AVMediaType
 
 #include <SDL_syswm.h>
@@ -51,7 +52,7 @@ class VTMetalRenderer;
 
 @end
 
-class VTMetalRenderer : public VTBaseRenderer
+class VTMetalRenderer : public VTBaseRenderer, public IVrrFramePresenter
 {
 public:
     VTMetalRenderer(bool hwAccel)
@@ -62,6 +63,13 @@ public:
           m_MetalLayer(nullptr),
           m_MetalDisplayLink(nullptr),
           m_LatestUnrenderedFrame(nullptr),
+          m_PreparedVrrFrame(nullptr),
+          m_VrrPresentPending(false),
+          m_VrrPresentComplete(false),
+          m_VrrSuspended(false),
+          m_VrrEnabled(false),
+          m_FixedFrameRate(0),
+          m_VrrPresentSerial(0),
           m_FrameLock(SDL_CreateMutex()),
           m_FrameReady(SDL_CreateCond()),
           m_TextureCache(nullptr),
@@ -87,6 +95,7 @@ public:
         // Stop the display link and free associated state
         stopDisplayLink();
         av_frame_free(&m_LatestUnrenderedFrame);
+        av_frame_free(&m_PreparedVrrFrame);
         SDL_DestroyCond(m_FrameReady);
         SDL_DestroyMutex(m_FrameLock);
 
@@ -474,7 +483,7 @@ public:
     }}
 
     // Caller frees frame after we return
-    virtual void renderFrameIntoDrawable(AVFrame* frame, id<CAMetalDrawable> drawable)
+    virtual uint64_t renderFrameIntoDrawable(AVFrame* frame, id<CAMetalDrawable> drawable)
     { @autoreleasepool {
         std::array<CVMetalTextureRef, MAX_VIDEO_PLANES> cvMetalTextures;
         size_t planes = getFramePlaneCount(frame);
@@ -482,7 +491,7 @@ public:
 
         if (frame->format == AV_PIX_FMT_VIDEOTOOLBOX) {
             if (!createTexturesFromFrame(frame, cvMetalTextures)) {
-                return;
+                return 0;
             }
         }
 
@@ -565,11 +574,13 @@ public:
         [renderEncoder endEncoding];
 
         // Flip to the newly rendered buffer
+        const uint64_t submissionTimeUs = LiGetMicroseconds();
         [commandBuffer presentDrawable:drawable];
         [commandBuffer commit];
 
         // Wait for the command buffer to complete and free our CVMetalTextureCache references
         [commandBuffer waitUntilCompleted];
+        return submissionTimeUs;
     }}
 
     // Caller frees frame after we return
@@ -662,7 +673,11 @@ public:
         int err;
 
         m_Window = params->window;
-        m_FrameRateRange = CAFrameRateRangeMake(params->frameRate, params->frameRate, params->frameRate);
+        m_VrrEnabled = params->enableVrr;
+        m_FixedFrameRate = params->frameRate;
+        m_FrameRateRange = m_VrrEnabled ?
+            CAFrameRateRangeMake(1, params->vrrDisplayRefreshHz, params->frameRate) :
+            CAFrameRateRangeMake(params->frameRate, params->frameRate, params->frameRate);
 
         id<MTLDevice> device = getMetalDevice();
         if (!device) {
@@ -744,6 +759,135 @@ public:
 
         return true;
     }}
+
+    virtual IVrrFramePresenter* getVrrFramePresenter() override
+    {
+        return this;
+    }
+
+    virtual VrrFallbackReason checkSupport() const override
+    {
+        if (!m_VrrEnabled) {
+            return VrrFallbackReason::UnsupportedRenderer;
+        }
+        if (@available(macOS 14, *)) {
+            if (!isAppleSilicon() || m_MetalLayer == nullptr ||
+                    !m_MetalLayer.displaySyncEnabled) {
+                return VrrFallbackReason::AdaptivePresentationUnavailable;
+            }
+            return VrrFallbackReason::NoFallback;
+        }
+        return VrrFallbackReason::AdaptivePresentationUnavailable;
+    }
+
+    virtual VrrPrepareResult prepareFrame(AVFrame* frame) override
+    { @autoreleasepool {
+        VrrPrepareResult result;
+        if (frame == nullptr || m_VrrSuspended ||
+                checkSupport() != VrrFallbackReason::NoFallback) {
+            return result;
+        }
+
+        if (!updateColorSpaceForFrame(frame) ||
+                !updateVideoRegionSizeForFrame(frame)) {
+            SDL_Event event;
+            event.type = SDL_RENDER_DEVICE_RESET;
+            SDL_PushEvent(&event);
+            return result;
+        }
+
+        startDisplayLink();
+        if (!hasDisplayLink()) {
+            return result;
+        }
+
+        AVFrame* preparedFrame = av_frame_alloc();
+        if (preparedFrame == nullptr || av_frame_ref(preparedFrame, frame) < 0) {
+            av_frame_free(&preparedFrame);
+            return result;
+        }
+
+        SDL_LockMutex(m_FrameLock);
+        av_frame_free(&m_PreparedVrrFrame);
+        m_PreparedVrrFrame = preparedFrame;
+        SDL_UnlockMutex(m_FrameLock);
+        result.prepared = true;
+        return result;
+    }}
+
+    virtual VrrPresentFeedback presentAdaptive(const VrrPresentRequest&) override
+    {
+        VrrPresentFeedback feedback;
+        SDL_LockMutex(m_FrameLock);
+        if (m_PreparedVrrFrame == nullptr || m_VrrSuspended || !hasDisplayLink()) {
+            SDL_UnlockMutex(m_FrameLock);
+            feedback.cancelled = true;
+            return feedback;
+        }
+
+        av_frame_free(&m_LatestUnrenderedFrame);
+        m_LatestUnrenderedFrame = m_PreparedVrrFrame;
+        m_PreparedVrrFrame = nullptr;
+        m_VrrPresentPending = true;
+        m_VrrPresentComplete = false;
+        const uint64_t presentSerial = ++m_VrrPresentSerial;
+        SDL_CondSignal(m_FrameReady);
+
+        while (!m_VrrPresentComplete && !m_VrrSuspended) {
+            if (SDL_CondWaitTimeout(m_FrameReady, m_FrameLock, 100) != 0) {
+                break;
+            }
+        }
+        if (m_VrrPresentComplete && presentSerial == m_VrrPresentSerial) {
+            feedback = m_VrrPresentFeedback;
+        }
+        else {
+            av_frame_free(&m_LatestUnrenderedFrame);
+            feedback.cancelled = true;
+        }
+        m_VrrPresentPending = false;
+        m_VrrPresentComplete = false;
+        SDL_UnlockMutex(m_FrameLock);
+        return feedback;
+    }
+
+    virtual VrrPresentFeedback cancelFrame() override
+    {
+        VrrPresentFeedback feedback;
+        feedback.cancelled = true;
+        SDL_LockMutex(m_FrameLock);
+        av_frame_free(&m_PreparedVrrFrame);
+        SDL_UnlockMutex(m_FrameLock);
+        return feedback;
+    }
+
+    virtual void setSuspended(bool suspended) override
+    {
+        SDL_LockMutex(m_FrameLock);
+        m_VrrSuspended = suspended;
+        if (suspended) {
+            av_frame_free(&m_PreparedVrrFrame);
+            av_frame_free(&m_LatestUnrenderedFrame);
+            m_VrrPresentFeedback = {};
+            m_VrrPresentFeedback.cancelled = true;
+            m_VrrPresentComplete = true;
+            SDL_CondBroadcast(m_FrameReady);
+        }
+        SDL_UnlockMutex(m_FrameLock);
+    }
+
+    virtual bool restoreFixedPresentation(VrrFallbackReason) override
+    {
+        m_VrrEnabled = false;
+        m_FrameRateRange = CAFrameRateRangeMake(
+            m_FixedFrameRate, m_FixedFrameRate, m_FixedFrameRate);
+        if (@available(macOS 14, *)) {
+            if (m_MetalDisplayLink != nullptr) {
+                m_MetalDisplayLink.preferredFrameRateRange = m_FrameRateRange;
+            }
+        }
+        return true;
+    }
 
     virtual void notifyOverlayUpdated(Overlay::OverlayType type) override
     { @autoreleasepool {
@@ -912,27 +1056,41 @@ public:
     void renderLatestFrameOnDrawable(id<CAMetalDrawable> drawable, CFTimeInterval targetTimestamp)
     {
         AVFrame* frame = nullptr;
+        uint64_t presentSerial = 0;
 
         // Determine how long we can wait depending on how long our CAMetalDisplayLink
         // says we have until the next frame needs to be rendered. We will wait up to
         // half the per-frame interval for a new frame to become available.
         int waitTimeMs = ((targetTimestamp - CACurrentMediaTime()) * 1000) / 2;
-        if (waitTimeMs < 0) {
-            return;
-        }
+        waitTimeMs = SDL_max(waitTimeMs, 0);
 
         // Wait for a new frame to be ready
         SDL_LockMutex(m_FrameLock);
         if (m_LatestUnrenderedFrame != nullptr || SDL_CondWaitTimeout(m_FrameReady, m_FrameLock, waitTimeMs) == 0) {
             frame = m_LatestUnrenderedFrame;
             m_LatestUnrenderedFrame = nullptr;
+            if (frame != nullptr && m_VrrPresentPending) {
+                presentSerial = m_VrrPresentSerial;
+            }
         }
         SDL_UnlockMutex(m_FrameLock);
 
         // Render a frame if we got one in time
         if (frame != nullptr) {
-            renderFrameIntoDrawable(frame, drawable);
+            const uint64_t submissionTimeUs = renderFrameIntoDrawable(frame, drawable);
             av_frame_free(&frame);
+
+            SDL_LockMutex(m_FrameLock);
+            if (m_VrrPresentPending && presentSerial != 0 &&
+                    presentSerial == m_VrrPresentSerial) {
+                m_VrrPresentFeedback = {};
+                m_VrrPresentFeedback.presented = submissionTimeUs != 0;
+                m_VrrPresentFeedback.submissionTimeValid = submissionTimeUs != 0;
+                m_VrrPresentFeedback.submissionTimeUs = submissionTimeUs;
+                m_VrrPresentComplete = true;
+                SDL_CondBroadcast(m_FrameReady);
+            }
+            SDL_UnlockMutex(m_FrameLock);
         }
     }
 
@@ -944,6 +1102,14 @@ private:
     CAMetalDisplayLink* m_MetalDisplayLink API_AVAILABLE(macos(14.0));
     CAFrameRateRange m_FrameRateRange;
     AVFrame* m_LatestUnrenderedFrame;
+    AVFrame* m_PreparedVrrFrame;
+    bool m_VrrPresentPending;
+    bool m_VrrPresentComplete;
+    bool m_VrrSuspended;
+    bool m_VrrEnabled;
+    int m_FixedFrameRate;
+    uint64_t m_VrrPresentSerial;
+    VrrPresentFeedback m_VrrPresentFeedback;
     SDL_mutex* m_FrameLock;
     SDL_cond* m_FrameReady;
     CVMetalTextureCacheRef m_TextureCache;


### PR DESCRIPTION
## Summary

macOS currently falls back to fixed pacing in the adaptive-frame-pacing branch; this adds a Metal presenter backed by `CAMetalDisplayLink`.

## Why This Exists

PR #1956 provides the shared VRR timing controller and native presenters for D3D11 and Vulkan, but it intentionally leaves Metal as a separately tested follow-up. Moonlight therefore cannot use that controller with the native VideoToolbox/Metal path on ProMotion Macs.

## Resolution

Make the Metal renderer implement `IVrrFramePresenter`. The shared worker retains ownership of source-cadence timing. Metal hands each prepared frame to `CAMetalDisplayLink`, uses a variable `CAFrameRateRange`, and reports the native drawable submission timestamp to the shared controller.

This follows Apple's display-link model instead of adding a second macOS-only timer.

## Reviewer Considerations

- This PR is stacked on #1956 and targets `Nonary:vrr-pacing`. It should be retargeted after that PR merges.
- Metal VRR is limited to the existing `CAMetalDisplayLink` eligibility: Apple Silicon, macOS 14 or newer, and V-sync enabled.
- `presentAdaptive()` waits for the display-link callback because that callback owns the drawable. The wait is bounded at 100 ms so teardown cannot deadlock.
- A presentation serial prevents a late callback from completing a newer frame after a timeout.
- This does not add server signaling or change Vulkan, D3D11, or fixed-pacing behavior.

## Behavior Changes

When VRR is enabled and the Metal renderer is selected on a supported Mac, Moonlight uses the shared adaptive pacing worker instead of falling back to fixed V-sync.

Unsupported systems continue through the base PR's fixed-pacing fallback.

## Implementation Summary

- Expose the Metal renderer through `IVrrFramePresenter`.
- Configure `CAMetalDisplayLink` with a variable frame-rate range for VRR sessions.
- Retain prepared AVFrames until the display-link callback submits their drawables.
- Return exact Metal submission timestamps to the shared timing controller.
- Restore the fixed frame-rate range on fallback.
- Bound callback waits and reject stale callback completions during teardown.

## Verification

- `python3 setup-deps.py`
- `qmake moonlight-qt.pro CONFIG+=release`
- `make -j8`
- `git diff --check`
- Ad-hoc signed and verified the macOS app bundle.
- Live-tested against devgen.local with 3840x2160, 90 FPS, 10-bit HDR, AV1, and VideoToolbox hardware decode.
- Confirmed: `VRR pacing: target 120 Hz with 90 FPS stream`.
- Confirmed: `Renderer 'VideoToolbox (Metal)' chosen`.
- Launched Rise of the Tomb Raider through Steam and verified the game process remained active.
- Ended the stream and confirmed the client exited cleanly after the bounded-wait fix.

The test server delivered about 115 FPS despite the requested 90 FPS, so the client dropped excess frames. That server-side cadence mismatch is outside this Metal presenter change.

## Risk

Moderate. This adds cross-thread ownership around the display-link callback. The state is mutex-protected, callback waits are bounded, and unsupported systems retain the existing fallback.
